### PR TITLE
Fix Exporter target switching

### DIFF
--- a/AlembicImporter/Assets/UTJ/Alembic/Scripts/Exporter/AlembicExporter.cs
+++ b/AlembicImporter/Assets/UTJ/Alembic/Scripts/Exporter/AlembicExporter.cs
@@ -67,7 +67,6 @@ namespace UTJ.Alembic
             m_firstFrame = true;
             m_prevFrame = -1;
 
-            m_recorder.targetBranch = gameObject;
             m_recorder.BeginRecording();
         }
 


### PR DESCRIPTION
This line of code was changing the target to always be current GameObject instead of whatever you dragged into the public property. Either change the wording to make it clear that you should drop component on the target, or remove this line as proposed. To elaborate:
A) you should not show a public target field on the inspector if you are meant to drop this component on the branch target. 
or
B) take pull request to make the target keep the GameObject that has been dragged into the filed.