### PR TITLE
Alembic jobification

### DIFF
--- a/Source/abci/Importer/AlembicImporter.cpp
+++ b/Source/abci/Importer/AlembicImporter.cpp
@@ -156,9 +156,7 @@ abciAPI aiSample* aiSchemaGetSample(aiSchema * schema)
 
 abciAPI void aiSchemaUpdateSample(aiSchema* schema, const abcSampleSelector *ss)
 {
-    if (schema)
-    {
-        schema->markForceSync();
+    if (schema) {
         schema->markForceUpdate();
         schema->updateSample(*ss);
     }
@@ -193,12 +191,6 @@ abciAPI aiProperty* aiSchemaGetPropertyByIndex(aiSchema* schema, int i)
 abciAPI aiProperty* aiSchemaGetPropertyByName(aiSchema* schema, const char *name)
 {
     return schema->getPropertyByName(name);
-}
-
-abciAPI void aiSampleSync(aiSample * sample)
-{
-    if (sample)
-        sample->waitAsync();
 }
 
 abciAPI void aiXformGetData(aiXformSample* sample, aiXformData *dst)

--- a/Source/abci/Importer/AlembicImporter.h
+++ b/Source/abci/Importer/AlembicImporter.h
@@ -108,8 +108,6 @@ struct aiConfig
     bool swap_handedness = true;
     bool swap_face_winding = false;
     bool interpolate_samples = true;
-    bool async_load = false;
-
     bool import_point_polygon = true;
     bool import_line_polygon = true;
     bool import_triangle_polygon = true;
@@ -280,8 +278,6 @@ abciAPI bool            aiSchemaIsDataUpdated(aiSchema* schema);
 abciAPI int             aiSchemaGetNumProperties(aiSchema* schema);
 abciAPI aiProperty*     aiSchemaGetPropertyByIndex(aiSchema* schema, int i);
 abciAPI aiProperty*     aiSchemaGetPropertyByName(aiSchema* schema, const char *name);
-
-abciAPI void            aiSampleSync(aiSample* sample);
 
 abciAPI void            aiXformGetData(aiXformSample* sample, aiXformData *dst);
 

--- a/Source/abci/Importer/aiPoints.cpp
+++ b/Source/abci/Importer/aiPoints.cpp
@@ -39,33 +39,29 @@ aiPointsSample::~aiPointsSample()
 
 void aiPointsSample::fillData(aiPointsData &data)
 {
-    auto body = [this, &data]() {
-            data.visibility = visibility;
+    data.visibility = visibility;
+    if (data.points)
+    {
+        if (!m_points_ref.empty())
+            m_points_ref.copy_to(data.points);
+    }
+    if (data.velocities)
+    {
+        if (!m_velocities.empty())
+            m_velocities.copy_to(data.velocities);
+        else
+            memset(data.velocities, 0, m_points_ref.size() * sizeof(abcV3));
+    }
 
-            if (data.points)
-            {
-                if (!m_points_ref.empty())
-                    m_points_ref.copy_to(data.points);
-            }
-            if (data.velocities)
-            {
-                if (!m_velocities.empty())
-                    m_velocities.copy_to(data.velocities);
-                else
-                    memset(data.velocities, 0, m_points_ref.size() * sizeof(abcV3));
-            }
-            if (data.ids)
-            {
-                if (!m_ids.empty())
-                    m_ids.copy_to(data.ids);
-                else
-                    memset(data.ids, 0, m_points_ref.size() * sizeof(uint32_t));
-            }
-            data.center = m_bb_center;
-            data.size = m_bb_size;
-        };
-
-    body();
+    if (data.ids)
+    {
+        if (!m_ids.empty())
+            m_ids.copy_to(data.ids);
+        else
+            memset(data.ids, 0, m_points_ref.size() * sizeof(uint32_t));
+    }
+    data.center = m_bb_center;
+    data.size = m_bb_size;
 }
 
 void aiPointsSample::getSummary(aiPointsSampleSummary & dst)

--- a/Source/abci/Importer/aiPoints.cpp
+++ b/Source/abci/Importer/aiPoints.cpp
@@ -35,7 +35,6 @@ aiPointsSample::aiPointsSample(aiPoints *schema)
 
 aiPointsSample::~aiPointsSample()
 {
-    waitAsync();
 }
 
 void aiPointsSample::fillData(aiPointsData &data)
@@ -66,22 +65,12 @@ void aiPointsSample::fillData(aiPointsData &data)
             data.size = m_bb_size;
         };
 
-    if (m_force_sync || !getConfig().async_load)
-        body();
-    else
-        m_async_copy = std::async(std::launch::async, body);
+    body();
 }
 
 void aiPointsSample::getSummary(aiPointsSampleSummary & dst)
 {
     dst.count = (int)m_points.size();
-}
-
-void aiPointsSample::waitAsync()
-{
-    if (m_async_copy.valid())
-        m_async_copy.wait();
-    m_force_sync = false;
 }
 
 aiPoints::aiPoints(aiObject *parent, const abcObject &abc)

--- a/Source/abci/Importer/aiPoints.h
+++ b/Source/abci/Importer/aiPoints.h
@@ -16,8 +16,6 @@ public:
     void fillData(aiPointsData &dst);
     void getSummary(aiPointsSampleSummary &dst);
 
-    void waitAsync() override;
-
 public:
     Abc::P3fArraySamplePtr m_points_sp, m_points_sp2;
     Abc::V3fArraySamplePtr m_velocities_sp;
@@ -30,8 +28,6 @@ public:
     RawVector<abcV3> m_velocities;
     RawVector<uint32_t> m_ids;
     abcV3 m_bb_center, m_bb_size;
-
-    std::future<void> m_async_copy;
 };
 
 struct aiPointsTraits

--- a/Source/abci/Importer/aiPolyMesh.cpp
+++ b/Source/abci/Importer/aiPolyMesh.cpp
@@ -112,7 +112,6 @@ aiPolyMeshSample::aiPolyMeshSample(aiPolyMesh *schema, TopologyPtr topo)
 
 aiPolyMeshSample::~aiPolyMeshSample()
 {
-    waitAsync();
 }
 
 void aiPolyMeshSample::reset()
@@ -251,17 +250,8 @@ void aiPolyMeshSample::fillVertexBuffer(aiPolyMeshData * vbs, aiSubmeshData * ib
                 fillSubmeshIndices(smi, ibs[smi]);
         };
 
-    if (m_force_sync || !getConfig().async_load)
-        body();
-    else
-        m_async_copy = std::async(std::launch::async, body);
-}
+    body();
 
-void aiPolyMeshSample::waitAsync()
-{
-    if (m_async_copy.valid())
-        m_async_copy.wait();
-    m_force_sync = false;
 }
 
 aiPolyMesh::aiPolyMesh(aiObject *parent, const abcObject &abc)

--- a/Source/abci/Importer/aiPolyMesh.cpp
+++ b/Source/abci/Importer/aiPolyMesh.cpp
@@ -242,16 +242,11 @@ void aiPolyMeshSample::fillSubmeshIndices(int submesh_index, aiSubmeshData &data
 
 void aiPolyMeshSample::fillVertexBuffer(aiPolyMeshData * vbs, aiSubmeshData * ibs)
 {
-    auto body = [this, vbs, ibs]() {
-            auto& refiner = m_topology->m_refiner;
-            for (int spi = 0; spi < (int)refiner.splits.size(); ++spi)
-                fillSplitVertices(spi, vbs[spi]);
-            for (int smi = 0; smi < (int)refiner.submeshes.size(); ++smi)
-                fillSubmeshIndices(smi, ibs[smi]);
-        };
-
-    body();
-
+    auto &refiner = m_topology->m_refiner;
+    for (int spi = 0; spi < (int) refiner.splits.size(); ++spi)
+        fillSplitVertices(spi, vbs[spi]);
+    for (int smi = 0; smi < (int) refiner.submeshes.size(); ++smi)
+        fillSubmeshIndices(smi, ibs[smi]);
 }
 
 aiPolyMesh::aiPolyMesh(aiObject *parent, const abcObject &abc)

--- a/Source/abci/Importer/aiPolyMesh.h
+++ b/Source/abci/Importer/aiPolyMesh.h
@@ -75,8 +75,6 @@ public:
     void fillSubmeshIndices(int submesh_index, aiSubmeshData &data) const;
     void fillVertexBuffer(aiPolyMeshData* vbs, aiSubmeshData* ibs);
 
-    void waitAsync() override;
-
 public:
     Abc::P3fArraySamplePtr m_points_sp, m_points_sp2;
     Abc::V3fArraySamplePtr m_velocities_sp;

--- a/Source/abci/Importer/aiSchema.cpp
+++ b/Source/abci/Importer/aiSchema.cpp
@@ -20,9 +20,6 @@ const aiConfig & aiSample::getConfig() const
     return m_schema->getConfig();
 }
 
-void aiSample::markForceSync() { m_force_sync = true; }
-
-
 aiSchema::aiSchema(aiObject *parent, const abcObject &abc)
     : super(parent->getContext(), parent, abc)
 {
@@ -36,7 +33,6 @@ aiSchema::~aiSchema()
 bool aiSchema::isConstant() const { return m_constant; }
 bool aiSchema::isDataUpdated() const { return m_data_updated; }
 void aiSchema::markForceUpdate() { m_force_update = true; }
-void aiSchema::markForceSync() { m_force_sync = true; }
 
 int aiSchema::getNumProperties() const
 {

--- a/Source/abci/Importer/aiSchema.h
+++ b/Source/abci/Importer/aiSchema.h
@@ -113,21 +113,12 @@ public:
     virtual void readSample(Sample& sample, uint64_t idx)
     {
         m_force_update_local = m_force_update;
-
-        auto body = [this, &sample, idx]() {
-                readSampleBody(sample, idx);
-            };
-
-        body();
+        readSampleBody(sample, idx);
     }
 
     virtual void cookSample(Sample& sample)
     {
-        auto body = [this, &sample]() {
-                cookSampleBody(sample);
-            };
-
-        body();
+        cookSampleBody(sample);
     }
 
 

--- a/Source/abci/Importer/aiSchema.h
+++ b/Source/abci/Importer/aiSchema.h
@@ -11,15 +11,11 @@ public:
     virtual aiSchema* getSchema() const { return m_schema; }
     const aiConfig& getConfig() const;
 
-    virtual void waitAsync() {}
-    void markForceSync();
-
 public:
     bool visibility = true;
 
 protected:
     aiSchema *m_schema = nullptr;
-    bool m_force_sync = false;
 };
 
 
@@ -49,7 +45,6 @@ protected:
     bool m_constant = false;
     bool m_data_updated = false;
     bool m_force_update = false;
-    bool m_force_sync = false;
     std::vector<aiPropertyPtr> m_properties; // sorted vector
 };
 
@@ -123,10 +118,7 @@ public:
                 readSampleBody(sample, idx);
             };
 
-        if (m_force_sync || !getConfig().async_load)
-            body();
-        else
-            m_async_load.m_read = body;
+        body();
     }
 
     virtual void cookSample(Sample& sample)
@@ -135,16 +127,9 @@ public:
                 cookSampleBody(sample);
             };
 
-        if (m_force_sync || !getConfig().async_load)
-            body();
-        else
-            m_async_load.m_cook = body;
+        body();
     }
 
-    void waitAsync() override
-    {
-        m_async_load.wait();
-    }
 
 protected:
     virtual void updateSampleBody(const abcSampleSelector& ss)
@@ -198,10 +183,7 @@ protected:
                 sample = nullptr;
         }
 
-        if (sample)
-        {
-            if (m_force_sync)
-                sample->markForceSync();
+        if (sample) {
 
             cookSample(*sample);
             m_data_updated = true;
@@ -214,7 +196,6 @@ protected:
 
         m_last_sample_index = sample_index;
         m_force_update = false;
-        m_force_sync = false;
     }
 
     virtual void readSampleBody(Sample& sample, uint64_t idx) = 0;

--- a/com.unity.formats.alembic/Documentation~/ref_StreamPlayer.md
+++ b/com.unity.formats.alembic/Documentation~/ref_StreamPlayer.md
@@ -9,5 +9,4 @@ The Alembic Stream Player component allows you to customize import and playback.
 | __Time Range__             | Select the range of the imported animation (in seconds) to be able to play back the animation. By default, this includes the entire animation. |
 | __Time__                   | Set the time in seconds of the animation that is currently displayed on the screen. This property operates like a playhead control, as you can scrub or animate it to play the animation. Valid values are from 0 to the length of the animation. |
 | __Vertex Motion Scale__    | Set the magnification factor when calculating velocity. Greater velocity means more blurring when used with Motion Blur. By default, the value is set to 1 (the velocity is not scaled). |
-| __Async Load__             | Enable this option to load the file asynchronously during playback. |
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -417,7 +417,6 @@ namespace UnityEngine.Formats.Alembic.Sdk
         [DllImport(Abci.Lib)] public static extern int aiPolyMeshGetSplitSummaries(IntPtr sample, IntPtr dst);
         [DllImport(Abci.Lib)] public static extern void aiPolyMeshGetSubmeshSummaries(IntPtr sample, IntPtr dst);
         [DllImport(Abci.Lib)] public static extern void aiPolyMeshFillVertexBuffer(IntPtr sample, IntPtr vbs, IntPtr ibs);
-        [DllImport(Abci.Lib)] public static extern void aiSampleSync(IntPtr sample);
 
         [DllImport(Abci.Lib)] public static extern void aiPointsGetSampleSummary(IntPtr sample, ref aiPointsSampleSummary dst);
         [DllImport(Abci.Lib)] public static extern void aiPointsFillData(IntPtr sample, IntPtr dst);

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -97,7 +97,6 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public Bool swapHandedness { get; set; }
         public Bool flipFaces { get; set; }
         public Bool interpolateSamples { get; set; }
-        public Bool asyncLoad { get; set; }
         public Bool importPointPolygon { get; set; }
         public Bool importLinePolygon { get; set; }
         public Bool importTrianglePolygon { get; set; }
@@ -117,7 +116,6 @@ namespace UnityEngine.Formats.Alembic.Sdk
             swapHandedness = true;
             flipFaces = false;
             interpolateSamples = true;
-            asyncLoad = true;
             importPointPolygon = true;
             importLinePolygon = true;
             importTrianglePolygon = true;
@@ -464,7 +462,6 @@ namespace UnityEngine.Formats.Alembic.Sdk
         public void GetSplitSummaries(PinnedList<aiMeshSplitSummary> dst) { NativeMethods.aiPolyMeshGetSplitSummaries(self, dst); }
         public void GetSubmeshSummaries(PinnedList<aiSubmeshSummary> dst) { NativeMethods.aiPolyMeshGetSubmeshSummaries(self, dst); }
         internal void FillVertexBuffer(PinnedList<aiPolyMeshData> vbs, PinnedList<aiSubmeshData> ibs) { NativeMethods.aiPolyMeshFillVertexBuffer(self, vbs, ibs); }
-        public void Sync() { NativeMethods.aiSampleSync(self); }
     }
 
     struct aiPointsSample
@@ -475,7 +472,6 @@ namespace UnityEngine.Formats.Alembic.Sdk
 
         public void GetSummary(ref aiPointsSampleSummary dst) { NativeMethods.aiPointsGetSampleSummary(self, ref dst); }
         public void FillData(PinnedList<aiPointsData> dst) { NativeMethods.aiPointsFillData(self, dst); }
-        public void Sync() { NativeMethods.aiSampleSync(self); }
     }
 
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
@@ -454,14 +455,36 @@ namespace UnityEngine.Formats.Alembic.Sdk
 
     struct aiPolyMeshSample
     {
+        [NativeDisableUnsafePtrRestriction]
         public IntPtr self;
         public static implicit operator bool(aiPolyMeshSample v) { return v.self != IntPtr.Zero; }
         public static implicit operator aiSample(aiPolyMeshSample v) { aiSample tmp; tmp.self = v.self; return tmp; }
 
         public void GetSummary(ref aiMeshSampleSummary dst) { NativeMethods.aiPolyMeshGetSampleSummary(self, ref dst); }
-        public void GetSplitSummaries(PinnedList<aiMeshSplitSummary> dst) { NativeMethods.aiPolyMeshGetSplitSummaries(self, dst); }
-        public void GetSubmeshSummaries(PinnedList<aiSubmeshSummary> dst) { NativeMethods.aiPolyMeshGetSubmeshSummaries(self, dst); }
-        internal void FillVertexBuffer(PinnedList<aiPolyMeshData> vbs, PinnedList<aiSubmeshData> ibs) { NativeMethods.aiPolyMeshFillVertexBuffer(self, vbs, ibs); }
+
+        public void GetSplitSummaries(NativeArray<aiMeshSplitSummary> dst)
+        {
+            unsafe
+            {
+                NativeMethods.aiPolyMeshGetSplitSummaries(self, new IntPtr(dst.GetUnsafePtr()));
+            }
+        }
+
+        public void GetSubmeshSummaries(NativeArray<aiSubmeshSummary> dst)
+        {
+            unsafe
+            {
+                NativeMethods.aiPolyMeshGetSubmeshSummaries(self, new IntPtr(dst.GetUnsafePtr()));
+            }
+        }
+
+        internal void FillVertexBuffer(NativeArray<aiPolyMeshData> vbs, NativeArray<aiSubmeshData> ibs)
+        {
+            unsafe
+            {
+                NativeMethods.aiPolyMeshFillVertexBuffer(self, new IntPtr(vbs.GetUnsafePtr()), new IntPtr(ibs.GetUnsafePtr()));
+            }
+        }
     }
 
     struct aiPointsSample

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace UnityEngine.Formats.Alembic.Sdk
@@ -295,6 +296,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
 
     struct aiContext
     {
+        [NativeDisableUnsafePtrRestriction]
         internal IntPtr self;
         public static implicit operator bool(aiContext v) { return v.self != IntPtr.Zero; }
         public static bool ToBool(aiContext v) { return v; }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -250,11 +250,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
             if (!m_abcSchema.schema.isDataUpdated)
                 return;
-
-            // wait async copy complete
-            var sample = m_abcSchema.sample;
-            sample.Sync();
-
+            
             bool topologyChanged = m_sampleSummary.topologyChanged;
             if (abcTreeNode.stream.streamDescriptor.Settings.ImportVisibility)
             {

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Unity.Collections;
+using Unity.Jobs;
 using UnityEngine;
 using UnityEngine.Formats.Alembic.Sdk;
 using UnityEngine.Rendering;
@@ -63,10 +65,12 @@ namespace UnityEngine.Formats.Alembic.Importer
         aiPolyMesh m_abcSchema;
         aiMeshSummary m_summary;
         aiMeshSampleSummary m_sampleSummary;
-        PinnedList<aiMeshSplitSummary> m_splitSummaries = new PinnedList<aiMeshSplitSummary>();
-        PinnedList<aiSubmeshSummary> m_submeshSummaries = new PinnedList<aiSubmeshSummary>();
-        PinnedList<aiPolyMeshData> m_splitData = new PinnedList<aiPolyMeshData>();
-        PinnedList<aiSubmeshData> m_submeshData = new PinnedList<aiSubmeshData>();
+        NativeArray<aiMeshSplitSummary> m_splitSummaries;
+        NativeArray<aiSubmeshSummary> m_submeshSummaries;
+        NativeArray<aiPolyMeshData> m_splitData;
+        NativeArray<aiSubmeshData> m_submeshData;
+
+        JobHandle fillVertexBufferHandle;
 
         List<Split> m_splits = new List<Split>();
         List<Submesh> m_submeshes = new List<Submesh>();
@@ -84,6 +88,11 @@ namespace UnityEngine.Formats.Alembic.Importer
             {
                 split.Dispose();
             }
+
+            m_splitSummaries.Dispose();
+            m_submeshSummaries.Dispose();;
+            m_splitData.Dispose();;
+            m_submeshData.Dispose();;
         }
 
         void UpdateSplits(int numSplits)
@@ -139,10 +148,42 @@ namespace UnityEngine.Formats.Alembic.Importer
             int splitCount = m_sampleSummary.splitCount;
             int submeshCount = m_sampleSummary.submeshCount;
 
-            m_splitSummaries.ResizeDiscard(splitCount);
-            m_splitData.ResizeDiscard(splitCount);
-            m_submeshSummaries.ResizeDiscard(submeshCount);
-            m_submeshData.ResizeDiscard(submeshCount);
+            if (m_splitSummaries.Length != splitCount)
+            {
+                if (m_splitSummaries.IsCreated)
+                {
+                    m_splitSummaries.Dispose();
+                }
+                m_splitSummaries = new NativeArray<aiMeshSplitSummary>(splitCount,Allocator.Persistent);
+            }
+
+            if (m_splitData.Length != splitCount)
+            {
+                if (m_splitData.IsCreated)
+                {
+                    m_splitData.Dispose();
+                }
+                m_splitData = new NativeArray<aiPolyMeshData>(splitCount,Allocator.Persistent);
+            }
+
+            if (m_submeshSummaries.Length != submeshCount)
+            {
+                if (m_submeshSummaries.IsCreated)
+                {
+                    m_submeshSummaries.Dispose();
+                }
+                m_submeshSummaries = new NativeArray<aiSubmeshSummary>(submeshCount, Allocator.Persistent);
+            }
+
+            if (m_submeshData.Length != submeshCount)
+            {
+                if (m_submeshData.IsCreated)
+                {
+                    m_submeshData.Dispose();
+                }
+
+                m_submeshData = new NativeArray<aiSubmeshData>(submeshCount,Allocator.Persistent);
+            }
 
             sample.GetSplitSummaries(m_splitSummaries);
             sample.GetSubmeshSummaries(m_submeshSummaries);
@@ -229,12 +270,25 @@ namespace UnityEngine.Formats.Alembic.Importer
                 }
             }
 
-            // kick async copy
-            sample.FillVertexBuffer(m_splitData, m_submeshData);
+            var job = new FillVertexBufferJob {sample = sample, splitData = m_splitData, submeshData = m_submeshData};
+
+            fillVertexBufferHandle = job.Schedule();
+        }
+
+        struct FillVertexBufferJob : IJob
+        {
+            public aiPolyMeshSample sample;
+            public NativeArray<aiPolyMeshData> splitData;
+            public NativeArray<aiSubmeshData> submeshData;
+            public void Execute()
+            {
+                sample.FillVertexBuffer(splitData, submeshData);
+            }
         }
 
         public override void AbcSyncDataEnd()
         {
+            fillVertexBufferHandle.Complete();
 #if UNITY_EDITOR
             for (int s = 0; s < m_splits.Count; ++s)
             {
@@ -250,7 +304,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
             if (!m_abcSchema.schema.isDataUpdated)
                 return;
-            
+
             bool topologyChanged = m_sampleSummary.topologyChanged;
             if (abcTreeNode.stream.streamDescriptor.Settings.ImportVisibility)
             {

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPoints.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicPoints.cs
@@ -75,11 +75,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         {
             if (!m_abcSchema.schema.isDataUpdated)
                 return;
-
-            var sample = m_abcSchema.sample;
-            // wait async copy complete
-            sample.Sync();
-
+            
             var data = m_abcData[0];
 
             if (abcTreeNode.stream.streamDescriptor.Settings.ImportVisibility)

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -75,7 +75,6 @@ namespace UnityEngine.Formats.Alembic.Importer
         internal aiConfig config { get { return m_config; } }
 
         public void SetVertexMotionScale(float value) { m_config.vertexMotionScale = value; }
-        public void SetAsyncLoad(bool value) { m_config.asyncLoad = value; }
 
         public void GetTimeRange(out double begin, out double end) { m_context.GetTimeRange(out begin, out end); }
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -223,7 +223,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             if (lastUpdateTime != CurrentTime || forceUpdate)
             {
                 abcStream.SetVertexMotionScale(VertexMotionScale);
-                abcStream.SetAsyncLoad(asyncLoad);
+
                 if (abcStream.AbcUpdateBegin(StartTime + CurrentTime))
                 {
                     lastUpdateTime = CurrentTime;

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -257,7 +257,7 @@ namespace UnityEngine.Formats.Alembic.Importer
                 LoadStream(false);
         }
 
-        void OnDestroy()
+        void OnDisable()
         {
             if (abcStream != null)
                 abcStream.Dispose();

--- a/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.asmdef
+++ b/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.asmdef
@@ -10,7 +10,7 @@
         "WindowsStandalone64"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,


### PR DESCRIPTION
This branch jobifies 2 parts of the Alembic update code:
* During the Update, an UpdateSamples job is launched. This reads the ABC file in native memory (1 per alembic file)
* During LateUpdate every Mesh launches a FillVertexBufferJob that converts the data from native to managed memory.

Removed the Async option as this was not gaining a lot of performance as is superseded by the UpdateSamples job.

Quick performance test:
100 instances of backflip ABC file:
before: 15FPS
after 90FPS