### PR TITLE
FTV-257 :Submeshes are created in the order of "discovered" face-sets

### DIFF
--- a/Source/abci/Foundation/aiMeshOps.cpp
+++ b/Source/abci/Foundation/aiMeshOps.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "aiMeshOps.h"
+#include <unordered_set>
 
 
 namespace impl
@@ -234,6 +235,9 @@ void MeshRefiner::genSubmeshes(IArray<int> material_ids)
     int num_splits = (int)splits.size();
     int offset_faces = 0;
     RawVector<Submesh> tmp_submeshes;
+    RawVector<int> materialOrder;
+    std::unordered_set<int> materialSet;
+
 
     for (int spi = 0; spi < num_splits; ++spi)
     {
@@ -254,9 +258,13 @@ void MeshRefiner::genSubmeshes(IArray<int> material_ids)
                     {
                         int id = (int)tmp_submeshes.size();
                         tmp_submeshes.push_back({});
-                        tmp_submeshes.back().material_id = id - 1;
                     }
                     tmp_submeshes[mid].index_count += (counts[fi] - 2) * 3;
+                    if (std::find(materialSet.begin(), materialSet.end(), mid) == materialSet.end() )
+                    {
+                        materialSet.insert(mid);
+                        materialOrder.push_back(mid);
+                    }
                 }
             }
 
@@ -281,8 +289,9 @@ void MeshRefiner::genSubmeshes(IArray<int> material_ids)
                 }
             }
 
-            for (int mi = 0; mi < (int)tmp_submeshes.size(); ++mi)
+            for(int i=0; i < materialOrder.size(); ++i)
             {
+                auto mi = materialOrder[i];
                 auto& sm = tmp_submeshes[mi];
                 if (sm.index_count > 0)
                 {
@@ -320,6 +329,8 @@ void MeshRefiner::genSubmeshes(IArray<int> material_ids)
 
         offset_faces += split.face_count;
         tmp_submeshes.clear();
+        materialOrder.clear();
+        materialSet.clear();
     }
     setupSubmeshes();
 }

--- a/Source/abci/Foundation/aiMeshOps.h
+++ b/Source/abci/Foundation/aiMeshOps.h
@@ -87,7 +87,6 @@ struct MeshRefiner
         int submesh_index = 0; // submesh index in split
         int index_count = 0; // triangulated
         int index_offset = 0;
-        int material_id = 0;
         int* dst_indices = nullptr;
     };
 


### PR DESCRIPTION
This branch creates the sub meshes in the order in which it "discovers" facesets:
This is important because we have workflows that clone the material assignments from FBX files and the meshes need to appear in the same order. This order is not give by any spec I found so far.

From the alembic SDK we receive an int for every face corresponding to the faceID:
Assume the following data for faces and faceIDs:
(f1,f2,f3,f4)->(2,2,1,1)
before:
sub mesh 1->(f3,f4)
sub mesh 2->(f1,f2)
after:
sub mesh 1->(f1,f2)
sub mesh 2->(f3,f4)

This was tested to do the right thing with multiple files exported from Maya and 3dsMax.