### PR TITLE
FTV-332: Add Warning in the AlembicImporter with HDF5

### DIFF
--- a/Source/abci/Importer/AlembicImporter.cpp
+++ b/Source/abci/Importer/AlembicImporter.cpp
@@ -44,6 +44,11 @@ abciAPI bool aiContextLoad(aiContext* ctx, const char *path)
     return ctx ? ctx->load(path) : false;
 }
 
+abciAPI bool aiContextGetIsHDF5(aiContext* ctx)
+{
+    return ctx ? ctx->getIsHDF5() : false;
+}
+
 abciAPI void aiContextSetConfig(aiContext* ctx, const aiConfig* conf)
 {
     if (ctx)

--- a/Source/abci/Importer/AlembicImporter.h
+++ b/Source/abci/Importer/AlembicImporter.h
@@ -247,6 +247,7 @@ abciAPI void            aiClearContextsWithPath(const char *path);
 abciAPI aiContext*      aiContextCreate(int uid);
 abciAPI void            aiContextDestroy(aiContext* ctx);
 abciAPI bool            aiContextLoad(aiContext* ctx, const char *path);
+abciAPI bool            aiContextGetIsHDF5(aiContext* ctx);
 abciAPI void            aiContextSetConfig(aiContext* ctx, const aiConfig* conf);
 abciAPI int             aiContextGetTimeSamplingCount(aiContext* ctx);
 abciAPI aiTimeSampling* aiContextGetTimeSampling(aiContext* ctx, int i);

--- a/Source/abci/Importer/aiContext.cpp
+++ b/Source/abci/Importer/aiContext.cpp
@@ -179,7 +179,8 @@ aiContextManager::~aiContextManager()
 }
 
 aiContext::aiContext(int uid)
-    : m_uid(uid)
+    : m_uid(uid),
+      m_isHDF5(false)
 {
 }
 
@@ -329,6 +330,7 @@ bool aiContext::load(const char *in_path)
             Alembic::AbcCoreOgawa::ReadArchive archive_reader(m_streams);
             m_archive = Abc::IArchive(archive_reader(m_path), Abc::kWrapExisting, Abc::ErrorHandler::kThrowPolicy);
             DebugLog("Successfully opened Ogawa archive");
+            m_isHDF5 = false;
         }
         catch (Alembic::Util::Exception e)
         {
@@ -344,6 +346,7 @@ bool aiContext::load(const char *in_path)
             {
                 m_archive = Abc::IArchive(AbcCoreHDF5::ReadArchive(), path);
                 DebugLog("Successfully opened HDF5 archive");
+                m_isHDF5 = true;
             }
             catch (Alembic::Util::Exception e2)
             {

--- a/Source/abci/Importer/aiContext.h
+++ b/Source/abci/Importer/aiContext.h
@@ -73,6 +73,7 @@ public:
 
     void queueAsync(aiAsync& task);
     void waitAsync();
+    bool getIsHDF5() const { return m_isHDF5; }
 
     template<class F>
     void eachNodes(const F &f);
@@ -91,6 +92,7 @@ private:
     aiConfig m_config;
 
     std::vector<aiAsync*> m_async_tasks;
+    bool m_isHDF5;
 };
 
 #include "aiObject.h"

--- a/com.unity.formats.alembic/Editor/Exporter/AlembicExporterEditor.cs
+++ b/com.unity.formats.alembic/Editor/Exporter/AlembicExporterEditor.cs
@@ -64,7 +64,23 @@ namespace UnityEditor.Formats.Alembic.Exporter
             EditorGUILayout.LabelField("Alembic Settings", EditorStyles.boldLabel);
             {
 #if !UNITY_EDITOR_LINUX
-                EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "conf.archiveType"));
+                var archiveProp = so.FindProperty(pathSettings + "conf.archiveType");
+                using (var hScope = new EditorGUILayout.HorizontalScope())
+                {
+                    using (var propertyScope = new EditorGUI.PropertyScope(hScope.rect,
+                        new GUIContent(archiveProp.displayName), archiveProp))
+                    {
+                        using (var changeScope = new EditorGUI.ChangeCheckScope())
+                        {
+                            var val = EditorGUILayout.EnumPopup(propertyScope.content, (ArchiveType) archiveProp.intValue, null,
+                                true);
+                            if (changeScope.changed)
+                            {
+                                archiveProp.intValue = (int)(ArchiveType)val;
+                            }
+                        }
+                    }
+                }
 #endif
                 EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "conf.xformType"));
                 var timeSamplingType = so.FindProperty(pathSettings + "conf.timeSamplingType");

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -69,7 +69,7 @@ namespace UnityEditor.Formats.Alembic.Importer
         }
     }
 
-    [ScriptedImporter(6, "abc")]
+    [ScriptedImporter(7, "abc")]
     internal class AlembicImporter : ScriptedImporter
     {
         [SerializeField]
@@ -120,6 +120,12 @@ namespace UnityEditor.Formats.Alembic.Importer
         }
 
         [SerializeField] bool firstImport = true;
+
+        internal bool IsHDF5
+        {
+            get { return isHDF5;}
+        }
+        [SerializeField] bool isHDF5;
 
         void OnValidate()
         {
@@ -187,6 +193,11 @@ namespace UnityEditor.Formats.Alembic.Importer
                 
                 ctx.AddObjectToAsset(prevIdName, go);
                 ctx.SetMainObject(go);
+                isHDF5 = abcStream.IsHDF5();
+                if (IsHDF5)
+                {
+                    Debug.LogWarning(path+": Deprecated HDF5 file format. Consider converting to Ogawa.");
+                }
             }
 
             firstImport = false;

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporterEditor.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporterEditor.cs
@@ -17,6 +17,11 @@ namespace UnityEditor.Formats.Alembic.Importer
             var importer = serializedObject.targetObject as AlembicImporter;
             var pathSettings = "streamSettings.";
 
+            if (importer.IsHDF5)
+            {
+                EditorGUILayout.HelpBox("Deprecated HDF5 file format. Consider converting to Ogawa.", MessageType.Warning);
+            }
+
             EditorGUILayout.LabelField("Scene", EditorStyles.boldLabel);
             {
                 EditorGUI.indentLevel++;

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -18,6 +18,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         /// <summary>
         /// HDF5 format (Deprecated).
         /// </summary>
+        [Obsolete]
         HDF5,
         /// <summary>
         /// Ogawa format.
@@ -370,6 +371,7 @@ namespace UnityEngine.Formats.Alembic.Sdk
         [DllImport(Abci.Lib)] public static extern aiContext aiContextCreate(int uid);
         [DllImport(Abci.Lib)] public static extern void aiContextDestroy(IntPtr ctx);
         [DllImport(Abci.Lib, BestFitMapping = false, ThrowOnUnmappableChar = true)] public static extern Bool aiContextLoad(IntPtr ctx, string path);
+        [DllImport(Abci.Lib)] public static extern bool aiContextGetIsHDF5(IntPtr ctx);
         [DllImport(Abci.Lib)] public static extern void aiContextSetConfig(IntPtr ctx, ref aiConfig conf);
         [DllImport(Abci.Lib)] public static extern int aiContextGetTimeSamplingCount(IntPtr ctx);
         [DllImport(Abci.Lib)] public static extern aiTimeSampling aiContextGetTimeSampling(IntPtr ctx, int i);

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -322,6 +322,11 @@ namespace UnityEngine.Formats.Alembic.Sdk
             return NativeMethods.aiContextLoad(self, fullPath);
         }
 
+        public bool IsHDF5()
+        {
+            return NativeMethods.aiContextGetIsHDF5(self);
+        }
+
         internal void SetConfig(ref aiConfig conf) { NativeMethods.aiContextSetConfig(self, ref conf); }
         public void UpdateSamples(double time) { NativeMethods.aiContextUpdateSamples(self, time); }
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -74,6 +74,11 @@ namespace UnityEngine.Formats.Alembic.Importer
         public bool abcIsValid { get { return m_context; } }
         internal aiConfig config { get { return m_config; } }
 
+        internal bool IsHDF5()
+        {
+            return m_context.IsHDF5();
+        }
+
         public void SetVertexMotionScale(float value) { m_config.vertexMotionScale = value; }
 
         public void GetTimeRange(out double begin, out double end) { m_context.GetTimeRange(out begin, out end); }


### PR DESCRIPTION
This PR adds a warning in the Importer inspector when a file is detected to be HDF5. 
The same warning gets written to the console on the first import.

The Alembic exporter displays the HDF5 Archive type as Obsolete.