### PR TITLE
FTV-342 : Crashes when importing animated alembic point clouds

### DIFF
--- a/Source/abci/Importer/aiPoints.cpp
+++ b/Source/abci/Importer/aiPoints.cpp
@@ -138,9 +138,10 @@ void aiPoints::readSampleBody(Sample & sample, uint64_t idx)
 
     // velocities
     sample.m_velocities_sp.reset();
-    if (m_summary.has_velocities)
+    auto velocityProp = m_schema.getVelocitiesProperty();
+    if (velocityProp.valid())
     {
-        m_schema.getVelocitiesProperty().get(sample.m_velocities_sp, ss);
+        velocityProp.get(sample.m_velocities_sp, ss);
     }
 
     // IDs


### PR DESCRIPTION
The problem appears when the ABC file has no velocities for points, but we ask to compute them: interpolate+constant point IDs.
The flag has_velocities is being reporposed.