### PR TITLE
FTV-346: Ui cleanup

### DIFF
--- a/com.unity.formats.alembic/Editor/Exporter/AlembicExporterEditor.cs
+++ b/com.unity.formats.alembic/Editor/Exporter/AlembicExporterEditor.cs
@@ -114,8 +114,8 @@ namespace UnityEditor.Formats.Alembic.Exporter
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "meshNormals"), new GUIContent("Normals"));
-                EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "meshUV0"), new GUIContent("UV 1"));
-                EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "meshUV1"), new GUIContent("UV 2"));
+                EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "meshUV0"), new GUIContent("UV 0"));
+                EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "meshUV1"), new GUIContent("UV 1"));
                 EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "meshColors"), new GUIContent("Vertex Color"));
                 EditorGUILayout.PropertyField(so.FindProperty(pathSettings + "meshSubmeshes"), new GUIContent("Submeshes"));
                 EditorGUI.indentLevel--;

--- a/com.unity.formats.alembic/Runtime/Shaders/HD.meta
+++ b/com.unity.formats.alembic/Runtime/Shaders/HD.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b891e5dc3a86e1f48a47e6e67548c6c2
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Small UI change to make the UV naming more uniform:
The exporter was using UV1 and UV2, switched to UV0 and UV1 (Same as setUV(int channel) )
Removed a meta file that is leftover from previous branch.