### PR TITLE
FTV-347: Leftover changes

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,0 +1,97 @@
+test_editors:
+  - version: 2019.2
+
+test_platforms:
+  - name: win
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  - name: mac
+    type: Unity::VM::osx
+    image: buildfarm/mac:stable
+    flavor: m1.mac
+---
+promotion_fetch:
+  name: Fetch Package From Internal Registry
+  agent:
+    type: Unity::VM::osx
+    image: buildfarm/mac:stable
+    flavor: m1.mac
+  variables:
+    UPMCI_PROMOTION: 1
+  commands:
+    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package pack --package-path com.unity.formats.alembic
+  artifacts:
+    packages:
+      paths:
+        - "upm-ci~/packages/**/*"
+
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+promotion_test_{{ platform.name }}_{{ editor.version }}:
+  name : Promotion Test {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  variables:
+    UPMCI_PROMOTION: 1
+  commands:
+    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.formats.alembic
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/promotion.yml#promotion_fetch
+{% endfor %}
+{% endfor %}
+
+promotion_test_trigger:
+  name: Promotion Tests Trigger
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+    packages:
+      paths:
+        - "upm-ci~/packages/**/*"
+  dependencies:
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+    - .yamato/promotion.yml#promotion_test_{{platform.name}}_{{editor.version}}
+{% endfor %}
+{% endfor %}
+
+promote:
+  name: Promote to Production
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  variables:
+    UPMCI_PROMOTION: 1
+  commands:
+    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package promote --package-path com.unity.formats.alembic
+  triggers:
+    tags:
+      only:
+        - /^\d+.\d+.\d+(-preview(.\d+)?)?$/
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/promotion.yml#promotion_fetch
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+    - .yamato/promotion.yml#promotion_test_{{ platform.name }}_{{ editor.version }}
+{% endfor %}
+{% endfor %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,6 +1,8 @@
 editors:
-  - version: 2019.2
-  - version: 2019.3  
+  - version: 2019.3
+  - version: 2020.1
+  - version: trunk
+
 platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -152,7 +152,7 @@ publish:
   triggers:
     tags:
       only:
-        - /^(v|V)[0-9]+.[0-9]+.[0-9]+/
+        - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
   artifacts:
     logs.zip:
       paths:

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changes in Alembic for Unity
 ## [2.0.0-preview.1] - 2019-08-07
 ### Changes
-- Minimum unity version is  2019.3.
+- Minimum Unity version is 2019.3.
 - Introduced public API for Alembic playback and recording. 
-- Multithread the loading of alembic files.
-- Removed the LitAlembic HDRP shader. The same features are supported by HDRP native shaders enabling 'Additional Velocity Change'.
+- Loading of Alembic files is now multi-threaded.
+- Removed the LitAlembic HDRP shader that has been obsoleted by HDRP native shaders that now offers the once missing velocity option.
 - HDF5 format is Obsolete.
-- Fixed a bug, where the face-id were being sorted in ascending order.
+- Fixed a bug where the face-id were being sorted in ascending order.
 - Fixed a bug that caused crashes when importing point clouds that had no velocity information.
 
 

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changes in Alembic for Unity
 ## [2.0.0-preview.1] - 2019-08-07
 ### Changes
-- Introduced public API for Alembic playback and recording. Bumped minimum Unity
-  version to 2019.2
+- Minimum unity version is  2019.3.
+- Introduced public API for Alembic playback and recording. 
+- Multithread the loading of alembic files.
+- Removed the LitAlembic HDRP shader. The same features are supported by HDRP native shaders enabling 'Additional Velocity Change'.
+- HDF5 format is Obsolete.
+- Fixed a bug, where the face-id were being sorted in ascending order.
+- Fixed a bug that caused crashes when importing point clouds that had no velocity information.
+
 
 ## [1.0.6] - 2019-08-26
 ### Changes

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -108,9 +108,6 @@ namespace UnityEngine.Formats.Alembic.Importer
         /// </summary>
         public AlembicStreamSettings Settings => StreamDescriptor !=null ? StreamDescriptor.Settings : null;
 
-        [SerializeField]
-        bool asyncLoad = true;
-        
         float lastUpdateTime;
         bool forceUpdate = false;
         bool updateStarted = false;

--- a/package.json.in
+++ b/package.json.in
@@ -17,8 +17,8 @@
     "repository": {
         "type": "git", 
         "revision": "@PACKAGE_REVISION@",
-        "url": "ssh://git@github.com/unity3d-jp/AlembicForUnity.git"
+        "url": "ssh://git@github.com:Unity-Technologies/AlembicForUnity.git"
     }, 
-    "unity": "2019.2",
+    "unity": "2019.3",
     "version": "2.0.0-preview.1"
 }


### PR DESCRIPTION
This implements a few tiny orphan tasks:
 
Write the Changelog
Update package.json to support unity 2019.3+
Update yamato to test on 2019.3, 2020.1, trunk
Remove AlembicStreamPlayer.asyncLoad that was causing warnings when the package was first imported (leftover from alembicJobification)