### PR TITLE
FTV-369: Export ever growing geometry

### DIFF
--- a/Source/abci/Exporter/aePolyMesh.cpp
+++ b/Source/abci/Exporter/aePolyMesh.cpp
@@ -105,14 +105,11 @@ void aePolyMesh::writeSampleBody()
         ApplyScale(m_buf_velocities.data(), (int)m_buf_velocities.size(), scale);
     }
 
-    // if face counts are empty, assume all faces are triangles
-    if (m_buf_faces.empty())
-    {
-        m_buf_faces.resize((int)(m_buf_indices.size() / 3), 3);
-    }
-
     // process submesh data if present
     {
+        m_buf_indices.resize(0);
+        m_buf_faces.resize(0);
+
         int offset_faces = 0;
         for (size_t smi = 0; smi < m_buf_submeshes.size(); ++smi)
         {

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,7 +8,7 @@
 - HDF5 format is Obsolete.
 - Fixed a bug where the face-id were being sorted in ascending order.
 - Fixed a bug that caused crashes when importing point clouds that had no velocity information.
-
+- Fixed a bug that caused exported geometries to have too many triangles.
 
 ## [1.0.6] - 2019-08-26
 ### Changes

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -658,7 +658,9 @@ namespace UnityEngine.Formats.Alembic.Util
                     else
                     {
                         if (m_meshBake == null)
-                            m_meshBake = new Mesh();
+                        {
+                            m_meshBake = new Mesh {name = m_target.name};
+                        }
 
                         m_meshBake.Clear();
                         m_target.BakeMesh(m_meshBake);

--- a/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
@@ -16,11 +16,23 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             var meshFiler = root.GetComponentInChildren<MeshFilter>();
             player.CurrentTime = 0;
             yield return new WaitForEndOfFrame();
-            var t0 = meshFiler.sharedMesh.vertices[0];
+            var vt0 = meshFiler.sharedMesh.vertices[0];
+            var vCount0 = meshFiler.sharedMesh.vertices.Length;
+            var idxCount0 = meshFiler.sharedMesh.GetIndexCount(0);
+            var subMeshCount0 = meshFiler.sharedMesh.subMeshCount;
             player.CurrentTime = (float)player.Duration;
             yield return new WaitForEndOfFrame();
-            var t1 = meshFiler.sharedMesh.vertices[0];
-            Assert.AreNotEqual(t0, t1);
+            var vt1 = meshFiler.sharedMesh.vertices[0];
+            var vCount1 = meshFiler.sharedMesh.vertices.Length;
+            var idxCount1 = meshFiler.sharedMesh.GetIndexCount(0);
+            var subMeshCount1 = meshFiler.sharedMesh.subMeshCount;
+
+            Assert.AreNotEqual(vt0, vt1); // It moves
+
+            // Geom does not grow
+            Assert.AreEqual(vCount0, vCount1);
+            Assert.AreEqual(idxCount0, idxCount1);
+            Assert.AreEqual(subMeshCount0, subMeshCount1);
         }
 
         [SetUp]


### PR DESCRIPTION
The alembic exporter was not clearing the Index buffer and the face buffer(a buffer describing the polygon count for the current face.) at the beginning of the frame resulting in ever growing geometries.