### PR TITLE
new OS-X yamato inage.

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,7 +10,7 @@ platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:latest
     flavor: m1.mac
   - name: centOS
     type: Unity::VM::GPU
@@ -36,7 +36,7 @@ build_mac:
   name: Build Mac
   agent:
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:latest
     flavor: m1.mac
   commands:
     - git submodule update --init --recursive
@@ -65,7 +65,7 @@ pack:
   name: Pack
   agent:
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:latest
     flavor: m1.mac
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm 


### PR DESCRIPTION
Packman changed their requirements for upm-ci@latest and it is incompatible with the old build farm machines.