### PR TITLE
FTV-759 Update Alembic namespace

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,8 @@
 editors:
-  - version: 2019.4  
+  - version: 2019.4 
+  - version: 2020.1
+  - version: trunk
+
 platforms:
   - name: win
     type: Unity::VM

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -1,14 +1,14 @@
-#if UNITY_2017_1_OR_NEWER
-
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
-using UnityEditor;
 using UnityEngine;
-using UnityEditor.Experimental.AssetImporters;
 using UnityEngine.Formats.Alembic.Importer;
 using UnityEngine.Formats.Alembic.Sdk;
 using Object = UnityEngine.Object;
+#if UNITY_2020_2_OR_NEWER
+    using UnityEditor.AssetImporters;
+#else
+    using UnityEditor.Experimental.AssetImporters;
+#endif
 
 namespace UnityEditor.Formats.Alembic.Importer
 {
@@ -398,5 +398,3 @@ namespace UnityEditor.Formats.Alembic.Importer
         }
     }
 }
-
-#endif

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporterEditor.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporterEditor.cs
@@ -5,7 +5,11 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Formats.Alembic.Sdk;
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters;
+#else
 using UnityEditor.Experimental.AssetImporters;
+#endif
 
 namespace UnityEditor.Formats.Alembic.Importer
 {


### PR DESCRIPTION
2020.2 changes the namespace for  ScriptedImporter.
Backport from: https://github.com/Unity-Technologies/AlembicForUnity/pull/342