### PR TITLE
Convert the Burst dependency to a soft one.

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changes
 - Fixed a bug where the visibility was not properly read if it was the only animated property of the object. 
 - When the timeline does discontinuous updates, the alembic updates the scene synchronously.
+- Add a conditinal dependency on Burst >= 1.2.0
 
 ## [2.1.0-preview.1] - 2020-06-16
 ### Feature

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -292,8 +292,9 @@ namespace UnityEngine.Formats.Alembic.Importer
                 sample.FillVertexBuffer(splitData, submeshData);
             }
         }
-
+#if BURST_AVAILABLE
         [BurstCompile]
+#endif
         struct MultiplyByConstant : IJobParallelFor
         {
             [NativeDisableUnsafePtrRestriction]

--- a/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.asmdef
+++ b/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.asmdef
@@ -16,6 +16,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.burst",
+            "expression": "1.2.0",
+            "define": "BURST_AVAILABLE"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "com.unity.timeline": "1.0.0",
-    "com.unity.burst": "1.2.3"
+    "com.unity.timeline": "1.0.0"
   },
   "description": "The Alembic package provides support to import and export Alembic files (.abc). Alembic is a format commonly used in animation to transfer facial, cloth, and other simulation between applications.",
   "displayName": "Alembic",


### PR DESCRIPTION
Burst created some issues for people trying to build with Mono x86_64 with a valid c++ compiler in their environment.
Switched to a conditional dependency.
This could impact slightly performance of the motion vector update.