### PR TITLE
ABC-160: Hide out of project asset stream incomplete API

### DIFF
--- a/TestProjects/AlembicRecorder/Assets/Tests/Unity.Formats.Alembic.RecorderTests.Runtime.asmdef
+++ b/TestProjects/AlembicRecorder/Assets/Tests/Unity.Formats.Alembic.RecorderTests.Runtime.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Unity.Formats.Alembic.RecorderTests.Runtime",
+    "name": "Unity.Formats.Alembic.RecorderTests.Editor",
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AbcAPI.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 [assembly: InternalsVisibleTo("Unity.Formats.Alembic.UnitTests.Editor")]
 [assembly: InternalsVisibleTo("Unity.Formats.Alembic.UnitTests.Runtime")]
+[assembly: InternalsVisibleTo("Unity.Formats.Alembic.RecorderTests.Editor")]
 [assembly: InternalsVisibleTo("Unity.Formats.Alembic.Tests")]
 [assembly: InternalsVisibleTo("Unity.Formats.Alembic.Editor")]
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -129,7 +129,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         /// </summary>
         /// <param name="newPath">Path to the new file.</param>
         /// <returns>True if the load succeeded, false otherwise.</returns>
-        public bool LoadFromFile(string newPath)
+        internal bool LoadFromFile(string newPath)
         {
             if (StreamDescriptor == null)
             {

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -104,7 +104,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         public string PathToAbc => StreamDescriptor != null ? StreamDescriptor.PathToAbc : "";
 
         /// <summary>
-        /// The stream import options.
+        /// The stream import options. NOTE: these options are shared between all instances of this asset.
         /// </summary>
         public AlembicStreamSettings Settings => StreamDescriptor != null ? StreamDescriptor.Settings : null;
 

--- a/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.api
+++ b/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.api
@@ -49,7 +49,6 @@ namespace UnityEngine.Formats.Alembic.Importer
         public float StartTime { get; set; }
         public float VertexMotionScale { get; set; }
         public AlembicStreamPlayer() {}
-        public bool LoadFromFile(string newPath);
         public void UpdateImmediately(float time);
     }
 


### PR DESCRIPTION
The feature to stream a file from project got pushed to a later version.
Removing the API that allowed for a crappy workflow (cannot change the alembic import properties and the inspector UI is not implemented)