### PR TITLE
Fix Promotion

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,5 +1,5 @@
 test_editors:
-  - version: 2019.2
+  - version: 2019.4
 
 test_platforms:
   - name: win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,5 @@
 editors:
-  - version: 2019.3
+  - version: 2019.4
   - version: 2020.1
   - version: trunk
 

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes in Alembic for Unity
 
-## [2.1.0-preview.2] - 2020-09-24
+## [2.1.0-preview.3] - 2020-09-24
 ### Feature
 - Added Unity recorder integration (compatible with Unity Recorder >= 2.2.0).
 

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -210,7 +210,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             var root = PrefabUtility.InstantiatePrefab(go) as GameObject;
             var player = root.GetComponent<AlembicStreamPlayer>();
             var timeline = director.playableAsset as TimelineAsset;
-            var abcTrack = timeline.CreateTrack<AlembicTrack>();
+            var abcTrack = timeline.CreateTrack<AlembicTrack>(null,"");
             var clip = abcTrack.CreateClip<AlembicShotAsset>();
             var abcAsset = clip.asset as AlembicShotAsset;
             var refAbc = new ExposedReference<AlembicStreamPlayer> {exposedName = Guid.NewGuid().ToString()};

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -15,5 +15,5 @@
   ],
   "name": "com.unity.formats.alembic",
   "unity": "2019.3",
-  "version": "2.1.0-preview.2"
+  "version": "2.1.0-preview.3"
 }


### PR DESCRIPTION
Promotion failed because it was running on 2019.2
Fixed both testing version as well as actual unit test that was using a newer Timeline API 