### PR TITLE
Package version

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes in Alembic for Unity
 
-## [2.1.0-preview.4] - 2020-09-24
+## [2.1.1-pre.1] - 2020-10-21
 ### Feature
 - Added Unity recorder integration (compatible with Unity Recorder >= 2.2.0).
 

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Fixed a bug that caused a crash when exporting a GameObject with a MeshRender but without a MeshFilter Component.
 - Fixed a bug where the visibility was not properly read if it was the only animated property of the object. 
 - When the timeline does discontinuous time updates (scrubbing), the alembic updates the scene synchronously.
-- Updated dependency to Burst 1.3.6 (Eliminate the need to have a C++ compiler for x86-64 Mono builds).
+- Updated optional dependency to Burst 1.1.1 or newer.
 
 ## [2.0.1-preview.1] - 2020-05-29
 ### Changes

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -292,8 +292,9 @@ namespace UnityEngine.Formats.Alembic.Importer
                 sample.FillVertexBuffer(splitData, submeshData);
             }
         }
-
+#if BURST_AVAILABLE
         [BurstCompile]
+#endif
         struct MultiplyByConstant : IJobParallelFor
         {
             [NativeDisableUnsafePtrRestriction]

--- a/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.asmdef
+++ b/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.asmdef
@@ -16,6 +16,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.burst",
+            "expression": "1.1.1",
+            "define": "BURST_AVAILABLE"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -15,5 +15,5 @@
   ],
   "name": "com.unity.formats.alembic",
   "unity": "2019.3",
-  "version": "2.1.0-preview.4"
+  "version": "2.1.1-pre.1"
 }

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "com.unity.timeline": "1.0.0",
-    "com.unity.burst": "1.3.6"
+    "com.unity.timeline": "1.0.0"
   },
   "description": "Import and export Alembic files (.abc), record and stream animations in the Alembic format directly in Unity.\n\nThe Alembic format is commonly used in animation to transfer facial, cloth, and other simulation between applications.\n\nIMPORTANT: Alembic for Unity ony supports Windows 64-bit, MacOS X and Linux 64-bit as build targets.",
   "displayName": "Alembic",


### PR DESCRIPTION
This PR updates the package version to 2.1.1-pre.1 (2021.1 verification start)
The Burst dependency was switched to a soft one, since it's very complicated managing dependencies for verified packages (very strict version enforcing)