### PR TITLE
Fix unstable tests

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,4 +1,5 @@
 editors:
+  - version: 2019.3
   - version: 2019.4
   - version: 2020.1
   - version: 2020.2

--- a/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
@@ -79,7 +79,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             SceneManager.SetActiveScene(scene);
             var go = new GameObject("Recorder");
             exporter = go.AddComponent<AlembicExporter>();
-            exporter.MaxCaptureFrame = 10;
+            exporter.MaxCaptureFrame = 20;
             exporter.Recorder.Settings.OutputPath =
                 "Assets/" + Path.GetFileNameWithoutExtension(Path.GetTempFileName()) + ".abc";
             exporter.CaptureOnStart = false;

--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -31,8 +31,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             player.CurrentTime = 0;
             yield return new WaitForEndOfFrame();
             var t0 = cubeGO.transform.position;
-            player.CurrentTime = (float)player.Duration;
-            yield return new WaitForEndOfFrame();
+            player.UpdateImmediately(player.Duration - 1e-5f);
             var t1  = cubeGO.transform.position;
             Assert.AreNotEqual(t0, t1);
         }
@@ -210,7 +209,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             var root = PrefabUtility.InstantiatePrefab(go) as GameObject;
             var player = root.GetComponent<AlembicStreamPlayer>();
             var timeline = director.playableAsset as TimelineAsset;
-            var abcTrack = timeline.CreateTrack<AlembicTrack>(null,"");
+            var abcTrack = timeline.CreateTrack<AlembicTrack>(null, "");
             var clip = abcTrack.CreateClip<AlembicShotAsset>();
             var abcAsset = clip.asset as AlembicShotAsset;
             var refAbc = new ExposedReference<AlembicStreamPlayer> {exposedName = Guid.NewGuid().ToString()};


### PR DESCRIPTION
Timing was too tight. Use immediate update and stay away from very last frame.
Hopefully get better stats than this: https://hoarder.hq.unity3d.com/?SubmitterId=92&TestSessionStartDate=2020-12-01T05:00:00.000Z&TestSessionEndDate=2020-12-16T04:59:59.000Z