### PR TITLE
Fix regExps for publish and promote

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -85,7 +85,7 @@ promote:
   triggers:
     tags:
       only:
-        - /^\d+.\d+.\d+(-preview(.\d+)?)?$/
+        - /^\d+.\d+.\d+(-exp(.\d+)?)?$/  
   artifacts:
     artifacts:
       paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -257,7 +257,7 @@ publish:
   triggers:
     tags:
       only:
-        - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
+        - /^(r|R)(c|C)-\d+\.\d+\.\d+(-(exp|pre)(\.\d+)?)?$/  
   artifacts:
     logs.zip:
       paths:


### PR DESCRIPTION
The regexps were not lifecycleV2 compliant.