### PR TITLE
JIRA: ABC-185 Bring back the stride array

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added support for Stadia standalone builds.
 - The package depends on the Cloth Unity Module.
 - Fixed a bug, where degenerate triangles would create NaN normals.
+- Renamed AlembicCurve CurvePointCount to CurveOffsets, and changed the semantic to a stride array.
 
 ## [2.2.0-exp.1] - 2020-12-17
 ### Changes

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurves.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurves.cs
@@ -17,9 +17,9 @@ namespace UnityEngine.Formats.Alembic.Importer
         /// </summary>
         public Vector3[] Positions => positionsList.GetArray();
         /// <summary>
-        /// Returns an array where: the i-th entry returns how many points are contained in the i-th curve.
+        /// Returns an array where: the i-th entry returns the starting index of the i-th curve ( the i-th curve is between [StrideArray[i]..StrideArray[i+1]) ).
         /// </summary>
-        public int[] CurvePointCount => curvePointCount.GetArray();
+        public int[] StrideArray => strideArray.GetArray();
         /// <summary>
         /// Returns an array of UVs (optional), if the imported file contained UVs.
         /// </summary>
@@ -50,7 +50,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         OnUpdateDataHandler update;
 
         internal PinnedList<Vector3> positionsList { get; } = new PinnedList<Vector3>();
-        internal PinnedList<int> curvePointCount { get; } = new PinnedList<int>();
+        internal PinnedList<int> strideArray { get; } = new PinnedList<int>();
         internal PinnedList<Vector2> uvs { get; } = new PinnedList<Vector2>();
         internal PinnedList<float> widths { get; } = new PinnedList<float>();
         internal PinnedList<Vector3> velocitiesList { get; } = new PinnedList<Vector3>();

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurves.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurves.cs
@@ -17,9 +17,9 @@ namespace UnityEngine.Formats.Alembic.Importer
         /// </summary>
         public Vector3[] Positions => positionsList.GetArray();
         /// <summary>
-        /// Returns an array where: the i-th entry returns the starting index of the i-th curve ( the i-th curve is between [StrideArray[i]..StrideArray[i+1]) ).
+        /// Returns an array where: the i-th entry returns the starting index of the i-th curve ( the i-th curve is between [CurveOffsets[i]..CurveOffsets[i+1]-1) ).
         /// </summary>
-        public int[] StrideArray => strideArray.GetArray();
+        public int[] CurveOffsets => curveOffsets.GetArray();
         /// <summary>
         /// Returns an array of UVs (optional), if the imported file contained UVs.
         /// </summary>
@@ -50,7 +50,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         OnUpdateDataHandler update;
 
         internal PinnedList<Vector3> positionsList { get; } = new PinnedList<Vector3>();
-        internal PinnedList<int> strideArray { get; } = new PinnedList<int>();
+        internal PinnedList<int> curveOffsets { get; } = new PinnedList<int>();
         internal PinnedList<Vector2> uvs { get; } = new PinnedList<Vector2>();
         internal PinnedList<float> widths { get; } = new PinnedList<float>();
         internal PinnedList<Vector3> velocitiesList { get; } = new PinnedList<Vector3>();

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesElement.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesElement.cs
@@ -49,10 +49,10 @@ namespace UnityEngine.Formats.Alembic.Importer
                 curves.positionsList.ResizeDiscard(m_sampleSummary.positionCount);
                 curves.velocitiesList.ResizeDiscard(m_sampleSummary.positionCount);
 
-                curves.strideArray.ResizeDiscard(m_sampleSummary.numVerticesCount);
+                curves.curveOffsets.ResizeDiscard(m_sampleSummary.numVerticesCount);
                 data.positions = curves.positionsList;
                 data.velocities = curves.velocitiesList;
-                data.numVertices = curves.strideArray;
+                data.numVertices = curves.curveOffsets;
             }
 
             if (m_summary.hasWidths)
@@ -84,10 +84,10 @@ namespace UnityEngine.Formats.Alembic.Importer
             var curves = abcTreeNode.gameObject.GetComponent<AlembicCurves>();
 
             var cnt = 0;
-            for (var i = 0; i < curves.StrideArray.Length; ++i)
+            for (var i = 0; i < curves.CurveOffsets.Length; ++i)
             {
-                var v = curves.StrideArray[i];
-                curves.StrideArray[i] = cnt;
+                var v = curves.CurveOffsets[i];
+                curves.CurveOffsets[i] = cnt;
                 cnt += v;
             }
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesElement.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesElement.cs
@@ -49,10 +49,10 @@ namespace UnityEngine.Formats.Alembic.Importer
                 curves.positionsList.ResizeDiscard(m_sampleSummary.positionCount);
                 curves.velocitiesList.ResizeDiscard(m_sampleSummary.positionCount);
 
-                curves.curvePointCount.ResizeDiscard(m_sampleSummary.numVerticesCount);
+                curves.strideArray.ResizeDiscard(m_sampleSummary.numVerticesCount);
                 data.positions = curves.positionsList;
                 data.velocities = curves.velocitiesList;
-                data.numVertices = curves.curvePointCount;
+                data.numVertices = curves.strideArray;
             }
 
             if (m_summary.hasWidths)
@@ -82,6 +82,15 @@ namespace UnityEngine.Formats.Alembic.Importer
                 abcTreeNode.gameObject.SetActive(data.visibility);
 
             var curves = abcTreeNode.gameObject.GetComponent<AlembicCurves>();
+
+            var cnt = 0;
+            for (var i = 0; i < curves.StrideArray.Length; ++i)
+            {
+                var v = curves.StrideArray[i];
+                curves.StrideArray[i] = cnt;
+                cnt += v;
+            }
+
             curves.InvokeOnUpdate(curves);
         }
     }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesRenderer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesRenderer.cs
@@ -47,6 +47,11 @@ namespace Scripts.Importer
 
         void UpdateMesh(AlembicCurves curves)
         {
+            if (curves.Positions.Length == 0)
+            {
+                return;
+            }
+
             GenerateLineMesh(mesh, curves.Positions, curves.CurveOffsets);
             /*    if (prevRenderMethod != renderMethod)
                 {

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesRenderer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesRenderer.cs
@@ -47,7 +47,7 @@ namespace Scripts.Importer
 
         void UpdateMesh(AlembicCurves curves)
         {
-            GenerateLineMesh(mesh, curves.Positions, curves.StrideArray);
+            GenerateLineMesh(mesh, curves.Positions, curves.CurveOffsets);
             /*    if (prevRenderMethod != renderMethod)
                 {
                     mesh.Clear();
@@ -158,8 +158,10 @@ namespace Scripts.Importer
                 vertices.CopyFrom(positionsM);
                 strideArray.CopyFrom(curveOffsetM);
 
+                // if there is only 1 curve, there is no meaningful curveOffset array, thus the length is the whole point array length
                 if (curveOffsetM.Length > 1)
                 {
+                    // Intermediate variable needs to be introduced because the a struct inside a "using" statement is assumed to immutable.
                     var nativeArray = curveCounts;
                     nativeArray[0] = curveOffsetM[1];
                 }

--- a/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.api
+++ b/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.api
@@ -29,8 +29,8 @@ namespace UnityEngine.Formats.Alembic.Importer
     [UnityEngine.DisallowMultipleComponent] public class AlembicCurves : UnityEngine.MonoBehaviour
     {
         public event UnityEngine.Formats.Alembic.Importer.AlembicCurves.OnUpdateDataHandler OnUpdateData;
-        public int[] CurvePointCount { get; }
         public UnityEngine.Vector3[] Positions { get; }
+        public int[] StrideArray { get; }
         public UnityEngine.Vector2[] UVs { get; }
         public UnityEngine.Vector3[] Velocities { get; }
         public float[] Widths { get; }

--- a/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.api
+++ b/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.api
@@ -29,8 +29,8 @@ namespace UnityEngine.Formats.Alembic.Importer
     [UnityEngine.DisallowMultipleComponent] public class AlembicCurves : UnityEngine.MonoBehaviour
     {
         public event UnityEngine.Formats.Alembic.Importer.AlembicCurves.OnUpdateDataHandler OnUpdateData;
+        public int[] CurveOffsets { get; }
         public UnityEngine.Vector3[] Positions { get; }
-        public int[] StrideArray { get; }
         public UnityEngine.Vector2[] UVs { get; }
         public UnityEngine.Vector3[] Velocities { get; }
         public float[] Widths { get; }

--- a/com.unity.formats.alembic/Tests/Runtime/CurveTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/CurveTests.cs
@@ -31,7 +31,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public void TestPositions()
         {
             Assert.AreEqual(5, streamPlayer.EndTime);
-            Assert.AreEqual(0, curves.StrideArray[0]);
+            Assert.AreEqual(0, curves.CurveOffsets[0]);
             {
                 streamPlayer.UpdateImmediately(0);
                 var expect = new Vector3(0.0042689126f, 0.010365379f, -0.00339815859f) * 100f; // points with default scale, scalled 100x

--- a/com.unity.formats.alembic/Tests/Runtime/CurveTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/CurveTests.cs
@@ -31,7 +31,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         public void TestPositions()
         {
             Assert.AreEqual(5, streamPlayer.EndTime);
-            Assert.AreEqual(curves.Positions.Length, curves.CurvePointCount[0]);
+            Assert.AreEqual(0, curves.StrideArray[0]);
             {
                 streamPlayer.UpdateImmediately(0);
                 var expect = new Vector3(0.0042689126f, 0.010365379f, -0.00339815859f) * 100f; // points with default scale, scalled 100x


### PR DESCRIPTION
Change the semantic of curvePointCount back to a stride array (and rename accordingly) as per the demo team's request.

@judubu please also validate propter naming if have better ideas :)