### PR TITLE
JIRA: ABC-181 Arm64 support

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -36,11 +36,23 @@ standalone_platforms:
     image: package-ci/mac:stable
     flavor: m1.mac
     runtime: standalone
-#  - name: centOS
-#    type: Unity::VM::GPU
-#    image: package-ci/centos:latest
-#    flavor: b1.large
-#    runtime: standalone
+
+bizarro_standalone_platforms:
+  - name: mac_m2
+    type: Unity::metal::devkit
+    image: package-ci/mac:stable
+    flavor: m1.mac
+    runtime: standalone
+  - name: centOS
+    type: Unity::VM::GPU
+    image: package-ci/centos:latest
+    flavor: b1.large
+    runtime: standalone
+  - name: stadia
+    type: Unity::VM
+    image: desktop/stadia-bka-katana:stable
+    flavor: b1.large
+    runtime: stadia
 
 ---
 build_win:
@@ -216,6 +228,53 @@ test_trigger:
     - .yamato/upm-ci.yml#testStandalone_{{platform.name}}_{{editor.version}}
     {% endfor %}
     {% endfor %}
+
+
+{% for platform in bizarro_standalone_platforms %}
+testBizarroStandalone_{{ platform.name }}:
+  name : Test Standalone on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+     - {% if platform.name == 'centOS' platform.name == 'stadia' %} DISPLAY=:0 {% endif %}  upm-ci project test  --project-path TestProjects/AlembicStandaloneBuild --type project-tests --unity-version 2021.1 --platform {{ platform.runtime }}
+  artifacts:
+    logs.zip:
+      paths:
+        - "upm-ci~/logs/**/*"
+        - "upm-ci~/test-results/**/*"
+    artifacts.zip:
+      paths:
+        - "upm-ci~/packages/**/*"
+        - "upm-ci~/templates/**/*"
+  dependencies:
+    - .yamato/upm-ci.yml#pack
+{% endfor %}
+
+test_bizarro:
+  name: TestsTriggerBizarro
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: b1.large
+  commands:
+    - dir
+  triggers:
+    cancel_old_ci: true
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+    packages:
+      paths:
+        - "upm-ci~/packages/**/*"
+  dependencies:    
+    {% for platform in bizarro_standalone_platforms %}  
+    - .yamato/upm-ci.yml#testBizarroStandalone_{{platform.name}}
+    {% endfor %}
+
 
 nightly_test_trigger:
   name: Nightly tests Trigger

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -48,11 +48,11 @@ bizarro_standalone_platforms:
     image: package-ci/centos:latest
     flavor: b1.large
     runtime: standalone
-  - name: stadia
-    type: Unity::VM
-    image: desktop/stadia-bka-katana:stable
-    flavor: b1.large
-    runtime: stadia
+  #- name: stadia
+  #  type: Unity::VM
+  #  image: desktop/stadia-bka-katana:stable
+  #  flavor: b1.large
+  #  runtime: stadia
 
 ---
 build_win:

--- a/External/build.sh
+++ b/External/build.sh
@@ -3,14 +3,6 @@
 installdir=$(pwd)/install
 tgzdir=$(pwd)
 
-# Produce fast and small code (but not debuggable), and produce it to be
-# relocatable since in the end we'll link it all together in a shared object.
-# Note that cmake seems to clobber the -O3 with a -O2, but we can dream.
-export CXXFLAGS="-O3 -fomit-frame-pointer -fPIC"
-export CFLAGS="-O3 -fomit-frame-pointer -fPIC"
-export MAKEFLAGS="-j12"
-
-
 if [[ -e ${installdir} ]]; then
     rm -rf ${installdir}
 fi

--- a/External/ispc/ispc-v1.14.1-linux.tar.gz
+++ b/External/ispc/ispc-v1.14.1-linux.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cc0dae16b3ac244aa05e8b1db1dadf35aeb8d67916aaee6b66efb813b8e9174
+size 42151379

--- a/External/ispc/ispc-v1.14.1-macOS.tar.gz
+++ b/External/ispc/ispc-v1.14.1-macOS.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50d5ba0268cd22a310eaf6ab4e00121bf83cc301396c6180e0fc1b897b40743c
+size 45111386

--- a/External/ispc/ispc-v1.14.1-windows.zip
+++ b/External/ispc/ispc-v1.14.1-windows.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6c49716300f2b15477c08b3ff71ef327709f38fd435b50c1301dbf9c92f0ea7
+size 40098645

--- a/External/ispc/ispc-v1.9.2-linux.tar.gz
+++ b/External/ispc/ispc-v1.9.2-linux.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8ddcd15f7579c4cc5fecc786be59e11513fec32115d520fc054abe5490e0016
-size 40644941

--- a/External/ispc/ispc-v1.9.2-osx.tar.gz
+++ b/External/ispc/ispc-v1.9.2-osx.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa307b97bea67d71aff046e3f69c0412cc950eda668a225e6b909dba752ef281
-size 56554892

--- a/External/ispc/ispc-v1.9.2-windows.zip
+++ b/External/ispc/ispc-v1.9.2-windows.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8fc795aac0877ef9ecbcf0855add92e466731e97feacbf5e1ff3cfd7129546bb
-size 31068606

--- a/Source/abci/CMakeLists.txt
+++ b/Source/abci/CMakeLists.txt
@@ -1,4 +1,8 @@
-option(ENABLE_ISPC "Use Intel ISPC to generate SIMDified code. It can significantly boost performance." ON)
+if( CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    option(ENABLE_ISPC "Use Intel ISPC to generate SIMDified code. It can significantly boost performance." OFF)
+else()
+    option(ENABLE_ISPC "Use Intel ISPC to generate SIMDified code. It can significantly boost performance." ON)
+endif()
 
 if(ENABLE_ISPC)
     find_package(ISPC REQUIRED)

--- a/Source/abci/CMakeLists.txt
+++ b/Source/abci/CMakeLists.txt
@@ -1,8 +1,4 @@
-if( CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    option(ENABLE_ISPC "Use Intel ISPC to generate SIMDified code. It can significantly boost performance." OFF)
-else()
-    option(ENABLE_ISPC "Use Intel ISPC to generate SIMDified code. It can significantly boost performance." ON)
-endif()
+option(ENABLE_ISPC "Use Intel ISPC to generate SIMDified code. It can significantly boost performance." ON)
 
 if(ENABLE_ISPC)
     find_package(ISPC REQUIRED)

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Produce fast and small code (but not debuggable), and produce it to be
+# relocatable since in the end we'll link it all together in a shared object.
+# Note that cmake seems to clobber the -O3 with a -O2, but we can dream.
+export CXXFLAGS="-O3 -fomit-frame-pointer -fPIC"
+export CFLAGS="-O3 -fomit-frame-pointer -fPIC"
+
+if [ "$(uname)" == "Darwin" ]; then
+   export CXXFLAGS="${CXXFLAGS} -arch x86_64 -arch arm64"
+   export CFLAGS="${CFLAGS} -arch x86_64 -arch arm64"
+
+fi
+
+export MAKEFLAGS="-j12"
+
 pushd External
 ./build.sh
 popd
@@ -7,9 +21,6 @@ popd
 if [[ -e build ]]; then
     rm -rf build
 fi
-
-export MAKEFLAGS="-j12"
-
 
 depsdir=${PWD}/External/install
 installdir=${PWD}

--- a/cmake/AddPlugin.cmake
+++ b/cmake/AddPlugin.cmake
@@ -30,31 +30,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 option(ENABLE_DEPLOY "Copy built binaries to plugins directory." ON)
 
-#macro(fix_default_compiler_settings_)
-#    if (MSVC AND NOT BUILD_SHARED_LIBS)
-#        # For MSVC, CMake sets certain flags to defaults we want to override.
-#        # This replacement code is taken from sample in the CMake Wiki at
-#        # http://www.cmake.org/Wiki/CMake_FAQ#Dynamic_Replace.
-#        foreach (flag_var
-#                CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-#                CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-#            string(REPLACE "/MD" "-MT" ${flag_var} "${${flag_var}}")
-#        endforeach()
-#    endif()
-#endmacro()
-
-# We create a ${name} target, which gets installed appropriately.
-# We create a ${name}_test_lib target, which does *not* get installed.
-# 
-# The reason is OSX: Unity needs a .bundle because it won't find a .dylib.
-# To do that you need a MODULE target. But you can't link to a MODULE to run
-# unit tests. So we create a ${name}_test_lib target on top of the ${name}
-# target. Oh, and it's STATIC because it's a pain to get the @rpath stuff to
-# work in a unit testing setting.
-#
-# On other platforms, the two targets are the same, just make sure you
-# link tests against the ${name}_test_lib target for your OSX colleagues.
-#
 function(add_plugin name)
     cmake_parse_arguments(arg "" "PLUGINS_DIR" "SOURCES" ${ARGN})
 
@@ -62,23 +37,8 @@ function(add_plugin name)
         # To use in Unity, it must be a bundle. A bundle must be a MODULE.
         add_library(${name} MODULE ${arg_SOURCES})
         set_target_properties(${name} PROPERTIES BUNDLE ON)
-
-        # A MODULE can't be used to link tests against. Also, dynamic linking
-        # gets you into rpath hell on OSX. So build a static lib on the side
-        # for unit testing.
-        add_library(${name}_test_lib STATIC ${arg_SOURCES})
-        target_link_libraries(${name}_test_lib PRIVATE $<TARGET_PROPERTY:${name},LINK_LIBRARIES>)
-        set_target_properties(${name}_test_lib PROPERTIES 
-                C_STANDARD $<TARGET_PROPERTY:${name},C_STANDARD>
-                COMPILE_DEFINITIONS $<TARGET_PROPERTY:${name},COMPILE_DEFINITIONS>
-                COMPILE_OPTIONS $<TARGET_PROPERTY:${name},COMPILE_OPTIONS>
-                INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>
-        )
     else()
-        # It's simpler on other platforms: we have a MODULE and that's it.
-        # Add the ALIAS so that the tests don't have to think about this mess.
         add_library(${name} MODULE ${arg_SOURCES})
-        add_library(${name}_test_lib ALIAS ${name})
         set_target_properties(${name} PROPERTIES PREFIX "")
     endif()
 

--- a/cmake/FindISPC.cmake
+++ b/cmake/FindISPC.cmake
@@ -52,6 +52,17 @@ function(add_ispc_targets)
             "${arg_OUTDIR}/${name}_avx${CMAKE_CXX_OUTPUT_EXTENSION}"
             "${arg_OUTDIR}/${name}_avx512skx${CMAKE_CXX_OUTPUT_EXTENSION}"
         )
+       
+        if( CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+            set(object_arm64 "${arg_OUTDIR}/${name}_arm64${CMAKE_CXX_OUTPUT_EXTENSION}")
+            add_custom_target(ISPC-ARM64 ALL
+                COMMAND ${ISPC} ${source} -o ${object_arm64} ${ISPC_OPTS} --target-os=ios --target=neon-i32x8 --opt=fast-masked-vload --opt=fast-math
+                DEPENDS ${source} ${arg_HEADERS}
+            )
+
+            list(APPEND objects ${object_arm64})
+        endif()
+
         set(outputs ${header} ${objects})
         add_custom_command(
             OUTPUT ${outputs}
@@ -59,10 +70,6 @@ function(add_ispc_targets)
             ARGS ${source} -o ${object} -h ${header} ${ISPC_OPTS} --target=sse4-i32x4,avx1-i32x8,avx512skx-i32x16 --arch=x86-64 --opt=fast-masked-vload --opt=fast-math
             DEPENDS ${source} ${arg_HEADERS}
             MAIN_DEPENDENCY ${source}
-            COMMENT "Building ISPC header ${header} and objects ${object} from ${source}"
-            # To reenable ISPC compile x86-64, compile aarch64 amd lipo...
-            #ispc aiSIMD.ispc -o blahiOS.o --target-os=ios --target=neon-i32x8 --opt=fast-masked-vload --opt=fast-math
-            # lipo blah* -create -output blahUniversal.o
         )
 
         list(APPEND _ispc_headers ${header})

--- a/cmake/FindISPC.cmake
+++ b/cmake/FindISPC.cmake
@@ -24,7 +24,7 @@ set(ISPC_VERSION 1.14.1)
         set(ISPC_DIR "ispc-v${ISPC_VERSION}-windows")
         execute_process(
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            COMMAND ${7ZA} x -aoa ${CMAKE_SOURCE_DIR}/External/ispc/${ISPC_DIR}.zip
+            COMMAND ${7ZA} x -aoa -o* ${CMAKE_SOURCE_DIR}/External/ispc/${ISPC_DIR}.zip
         )
     endif()
 
@@ -68,6 +68,7 @@ function(add_ispc_targets)
             OUTPUT ${outputs}
             COMMAND ${ISPC}
             ARGS ${source} -o ${object} -h ${header} ${ISPC_OPTS} --target=sse4-i32x4,avx1-i32x8,avx512skx-i32x16 --arch=x86-64 --opt=fast-masked-vload --opt=fast-math
+            COMMENT "running:  ${ISPC} ${source} -o ${object} -h ${header} ${ISPC_OPTS} --target=sse4-i32x4,avx1-i32x8,avx512skx-i32x16 --arch=x86-64 --opt=fast-masked-vload --opt=fast-math"
             DEPENDS ${source} ${arg_HEADERS}
             MAIN_DEPENDENCY ${source}
         )

--- a/cmake/FindISPC.cmake
+++ b/cmake/FindISPC.cmake
@@ -6,7 +6,7 @@ include(CMakeParseArguments)
 
 find_program(7ZA 7za HINTS ${CMAKE_SOURCE_DIR}/External/7z)
 
-set(ISPC_VERSION 1.9.2)
+set(ISPC_VERSION 1.14.1)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         set(ISPC_DIR "ispc-v${ISPC_VERSION}-linux")
         execute_process(
@@ -14,7 +14,7 @@ set(ISPC_VERSION 1.9.2)
             COMMAND tar -xf ${CMAKE_SOURCE_DIR}/External/ispc/${ISPC_DIR}.tar.gz
         )
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        set(ISPC_DIR "ispc-v${ISPC_VERSION}-osx")
+        set(ISPC_DIR "ispc-v${ISPC_VERSION}-macOS")
         execute_process(
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             COMMAND tar -xf ${CMAKE_SOURCE_DIR}/External/ispc/${ISPC_DIR}.tar.gz
@@ -28,7 +28,7 @@ set(ISPC_VERSION 1.9.2)
         )
     endif()
 
-    set(ISPC "${CMAKE_BINARY_DIR}/${ISPC_DIR}/ispc" CACHE PATH "" FORCE)
+    set(ISPC "${CMAKE_BINARY_DIR}/${ISPC_DIR}/bin/ispc" CACHE PATH "" FORCE)
 
 # e.g:
 #add_ispc_targets(
@@ -60,6 +60,9 @@ function(add_ispc_targets)
             DEPENDS ${source} ${arg_HEADERS}
             MAIN_DEPENDENCY ${source}
             COMMENT "Building ISPC header ${header} and objects ${object} from ${source}"
+            # To reenable ISPC compile x86-64, compile aarch64 amd lipo...
+            #ispc aiSIMD.ispc -o blahiOS.o --target-os=ios --target=neon-i32x8 --opt=fast-masked-vload --opt=fast-math
+            # lipo blah* -create -output blahUniversal.o
         )
 
         list(APPEND _ispc_headers ${header})

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changes in Alembic for Unity
 
 ## [2.2.0-exp.2] - 2021-01-04
-### Chnages
+### Changes
 - Updated to Alembic version 1.7.16.
 - Added support for Stadia standalone builds.
+- Added support for arm64 macOS.
 
 ## [2.2.0-exp.1] - 2020-12-17
 ### Changes


### PR DESCRIPTION
This branch adds support for Apple silicon binaries.
ISPC was upgraded to a version that supports Arm64, 1.14.1

There is a standalone test target, * mac_m2* that can be ran by hand (there are very few arm OSX's available le.)