### PR TITLE
JIRAL ABC-190 RemoveHDF5 Tests

### DIFF
--- a/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/TimelineDataTests.cs
@@ -98,17 +98,6 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             yield return TestCubeContents(go);
         }
 
-        [UnityTest, UnityPlatform(exclude = new[] {RuntimePlatform.LinuxEditor})]
-        public IEnumerator TestArchiveType([Values(ArchiveType.Ogawa, ArchiveType.HDF5)] int archiveType)
-        {
-            director.Play();
-            exporter.Recorder.Settings.ExportOptions.ArchiveType = (ArchiveType)archiveType;
-            yield return RecordAlembic();
-            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
-            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
-            yield return TestCubeContents(go);
-        }
-
         [UnityTest]
         public IEnumerator TestSwapHandedness([Values(true, false)] bool swap)
         {


### PR DESCRIPTION
These tests cause warnings and the format is removed in the next version altogether.