### PR TITLE
JIRA: ABC-38 HDRP Alembic shader aren't use by default on import

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 - Fixed a bug that caused the Alembic exporter to fail if GameObjects were being deleted during the recording session.
 - Fixed a memory leak that occurred when using varying topology meshes.
-
+- Added a custom dependency on the "CurrentRenderPipeline" setting and assigning the correct SRP by default.
 ## [2.2.0-exp.2] - 2021-01-21
 ### Added
 - Added support for Stadia standalone builds.

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Fixed
 - Fixed a bug that caused the Alembic exporter to fail if GameObjects were being deleted during the recording session.
 - Fixed a memory leak that occurred when using varying topology meshes.
-- Added a custom dependency on the "CurrentRenderPipeline" setting and assigning the correct SRP by default.
+- Added a custom dependency on the "CurrentRenderPipeline" setting and assigning the correct SRP material by default.
+
 ## [2.2.0-exp.2] - 2021-01-21
 ### Added
 - Added support for Stadia standalone builds.

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -250,10 +250,21 @@ namespace UnityEditor.Formats.Alembic.Importer
                 {
                     if (m_defaultMaterial == null)
                     {
-                        m_defaultMaterial = GetMaterial("Standard.shader");
+                        if (GraphicsSettings.currentRenderPipeline == null)
+                        {
+                            m_defaultMaterial = GetMaterial("Standard.shader");
+#if HDRP_PRESENT
+
+#endif
+                        }
+                        else
+                        {
+                            m_defaultMaterial = Instantiate(GraphicsSettings.currentRenderPipeline.defaultMaterial);
+                        }
+
+                        Add("Default Material", m_defaultMaterial);
                         m_defaultMaterial.hideFlags = HideFlags.NotEditable;
                         m_defaultMaterial.name = "Default Material";
-                        Add("Default Material", m_defaultMaterial);
                     }
                     return m_defaultMaterial;
                 }

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEditor.Experimental;
 using UnityEngine;
 using UnityEngine.Formats.Alembic.Importer;
 using UnityEngine.Formats.Alembic.Sdk;
@@ -9,13 +7,15 @@ using UnityEngine.Rendering;
 using Object = UnityEngine.Object;
 #if UNITY_2020_2_OR_NEWER
 using UnityEditor.AssetImporters;
+using static UnityEditor.AssetDatabase;
 #else
 using UnityEditor.Experimental.AssetImporters;
+using static UnityEditor.Experimental.AssetDatabaseExperimental;
 #endif
 
 namespace UnityEditor.Formats.Alembic.Importer
 {
-    internal class AlembicAssetModificationProcessor : UnityEditor.AssetModificationProcessor
+    class AlembicAssetModificationProcessor : AssetModificationProcessor
     {
         public static AssetDeleteResult OnWillDeleteAsset(string assetPath, RemoveAssetOptions rao)
         {
@@ -226,7 +226,7 @@ namespace UnityEditor.Formats.Alembic.Importer
             if (pipelineName != newPipelineName)
             {
                 var hash =  Hash128.Compute(newPipelineName);
-                AssetDatabaseExperimental.RegisterCustomDependency(renderPipepineDependency,hash);
+                RegisterCustomDependency(renderPipepineDependency, hash);
                 AssetDatabase.Refresh();
                 pipelineName = newPipelineName;
             }
@@ -291,11 +291,7 @@ namespace UnityEditor.Formats.Alembic.Importer
 
             public void Add(string identifier, Object asset)
             {
-#if UNITY_2017_3_OR_NEWER
                 m_ctx.AddObjectToAsset(identifier, asset);
-#else
-                m_ctx.AddSubAsset(identifier, asset);
-#endif
             }
 
             Material GetMaterial(string shaderFile)

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -253,13 +253,15 @@ namespace UnityEditor.Formats.Alembic.Importer
                         if (GraphicsSettings.currentRenderPipeline == null)
                         {
                             m_defaultMaterial = GetMaterial("Standard.shader");
-#if HDRP_PRESENT
-
-#endif
                         }
                         else
                         {
                             m_defaultMaterial = Instantiate(GraphicsSettings.currentRenderPipeline.defaultMaterial);
+                            // Enable the HDRP Custom Motion Vector Pass
+                            if (m_defaultMaterial.HasProperty("_AddPrecomputedVelocity"))
+                            {
+                                m_defaultMaterial.EnableKeyword("_ADD_PRECOMPUTED_VELOCITY");
+                            }
                         }
 
                         Add("Default Material", m_defaultMaterial);

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -259,6 +259,7 @@ namespace UnityEditor.Formats.Alembic.Importer
             Material m_defaultMaterial;
             Material m_defaultPointsMaterial;
             Material m_defaultPointsMotionVectorMaterial;
+            int addPrecomputedVelocityProperty = Shader.PropertyToID("_AddPrecomputedVelocity");
 
             public Subassets(AssetImportContext ctx)
             {
@@ -279,8 +280,9 @@ namespace UnityEditor.Formats.Alembic.Importer
                         {
                             m_defaultMaterial = Instantiate(GraphicsSettings.currentRenderPipeline.defaultMaterial);
                             // Enable the HDRP Custom Motion Vector Pass
-                            if (m_defaultMaterial.HasProperty("_AddPrecomputedVelocity"))
+                            if (m_defaultMaterial.HasProperty(addPrecomputedVelocityProperty))
                             {
+                                m_defaultMaterial.SetFloat(addPrecomputedVelocityProperty, 1);
                                 m_defaultMaterial.EnableKeyword("_ADD_PRECOMPUTED_VELOCITY");
                             }
                         }

--- a/com.unity.formats.alembic/Runtime/Scripts/Misc/Utils.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Misc/Utils.cs
@@ -28,5 +28,13 @@ namespace UnityEngine.Formats.Alembic.Importer
 
             return array;
         }
+
+        public static ulong CombineHash(this ulong h1, ulong h2)
+        {
+            unchecked
+            {
+                return h1 ^ h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2); // Similar to c++ boost::hash_combine
+            }
+        }
     }
 }


### PR DESCRIPTION
Alembic Mesh Default material support:
* legacy pipeline -> Alembic provided material with Motion Vectors
* HDRP -> Default Material (Lit) with custom velocity option
* URP -> Default ,material
This PR registers a custom dependency on ** GraphicsSettings.currentRenderPipeline** and retrievers an import if needed.