### PR TITLE
JIRA: ABC-105 Exported normals can't be read outside of Unity

### DIFF
--- a/Source/abci/Exporter/aePolyMesh.cpp
+++ b/Source/abci/Exporter/aePolyMesh.cpp
@@ -105,6 +105,9 @@ void aePolyMesh::writeSampleBody()
         ApplyScale(m_buf_velocities.data(), (int)m_buf_velocities.size(), scale);
     }
 
+    auto facecount = 0;
+    auto attribScope = Alembic::AbcGeom::GeometryScope::kFacevaryingScope;
+
     // process submesh data if present
     {
         m_buf_indices.resize(0);
@@ -138,6 +141,7 @@ void aePolyMesh::writeSampleBody()
                     break;
             }
             m_buf_faces.resize(m_buf_faces.size() + face_count, ngon);
+            facecount+= face_count * ngon;
 
             if (smi < m_facesets.size())
             {
@@ -152,6 +156,8 @@ void aePolyMesh::writeSampleBody()
 
             offset_faces += face_count;
         }
+
+        attribScope = facecount == m_buf_indices.size() ? Alembic::AbcGeom::GeometryScope::kFacevaryingScope : Alembic::AbcGeom::GeometryScope::kVertexScope;
     }
 
     // handle swap face option
@@ -178,7 +184,6 @@ void aePolyMesh::writeSampleBody()
                 }
             };
         do_swap(m_buf_indices);
-        do_swap(m_buf_uv0_indices);
     }
 
 
@@ -202,16 +207,16 @@ void aePolyMesh::writeSampleBody()
             sp.setIndices(Abc::UInt32ArraySample((const uint32_t*)m_buf_indices.data(), m_buf_indices.size()));
         }
 
-        sp.setScope(Alembic::AbcGeom::GeometryScope::kVertexScope);
+        sp.setScope(attribScope);
         sample.setNormals(sp);
     }
     if (!m_buf_uv0.empty())
     {
         AbcGeom::OV2fGeomParam::Sample sp;
         sp.setVals(Abc::V2fArraySample(m_buf_uv0.data(), m_buf_uv0.size()));
-        if (!m_buf_uv0_indices.empty())
-            sp.setIndices(Abc::UInt32ArraySample((const uint32_t*)m_buf_uv0_indices.data(), m_buf_uv0_indices.size()));
-        else if (m_buf_uv0.size() == m_buf_points.size())
+        sp.setScope(attribScope);
+
+        if (m_buf_uv0.size() == m_buf_points.size())
             sp.setIndices(Abc::UInt32ArraySample((const uint32_t*)m_buf_indices.data(), m_buf_indices.size()));
         sample.setUVs(sp);
     }
@@ -221,16 +226,16 @@ void aePolyMesh::writeSampleBody()
     {
         if (!m_uv1_param.valid())
         {
-            bool indexed = !m_buf_uv1_indices.empty() || m_buf_uv1.size() == m_buf_points.size();
+            bool indexed = m_buf_uv1.size() == m_buf_points.size();
             m_uv1_param = AbcGeom::OV2fGeomParam(
                 m_schema.getArbGeomParams(), "uv1", indexed, AbcGeom::GeometryScope::kConstantScope, m_buf_uv1.size(), getTimeSamplingIndex());
         }
 
         AbcGeom::OV2fGeomParam::Sample sp;
         sp.setVals(Abc::V2fArraySample(m_buf_uv1.data(), m_buf_uv1.size()));
-        if (!m_buf_uv1_indices.empty())
-            sp.setIndices(Abc::UInt32ArraySample((const uint32_t*)m_buf_uv1_indices.data(), m_buf_uv1_indices.size()));
-        else if (m_buf_uv1.size() == m_buf_points.size())
+        sp.setScope(attribScope);
+
+        if (m_buf_uv1.size() == m_buf_points.size())
             sp.setIndices(Abc::UInt32ArraySample((const uint32_t*)m_buf_indices.data(), m_buf_indices.size()));
         m_uv1_param.set(sp);
     }
@@ -239,16 +244,16 @@ void aePolyMesh::writeSampleBody()
     {
         if (!m_colors_param.valid())
         {
-            bool indexed = !m_buf_colors_indices.empty() || m_buf_colors.size() == m_buf_points.size();
+            bool indexed = m_buf_colors.size() == m_buf_points.size();
             m_colors_param = AbcGeom::OC4fGeomParam(
                 m_schema.getArbGeomParams(), "rgba", indexed, AbcGeom::GeometryScope::kConstantScope, m_buf_uv1.size(), getTimeSamplingIndex());
         }
 
         AbcGeom::OC4fGeomParam::Sample sp;
         sp.setVals(Abc::C4fArraySample((abcC4*)m_buf_colors.data(), m_buf_colors.size()));
-        if (!m_buf_colors_indices.empty())
-            sp.setIndices(Abc::UInt32ArraySample((const uint32_t*)m_buf_colors_indices.data(), m_buf_colors_indices.size()));
-        else if (m_buf_colors.size() == m_buf_points.size())
+        sp.setScope(attribScope);
+
+        if (m_buf_colors.size() == m_buf_points.size())
             sp.setIndices(Abc::UInt32ArraySample((const uint32_t*)m_buf_indices.data(), m_buf_indices.size()));
         m_colors_param.set(sp);
     }

--- a/Source/abci/Exporter/aePolyMesh.cpp
+++ b/Source/abci/Exporter/aePolyMesh.cpp
@@ -178,7 +178,6 @@ void aePolyMesh::writeSampleBody()
                 }
             };
         do_swap(m_buf_indices);
-        do_swap(m_buf_normal_indices);
         do_swap(m_buf_uv0_indices);
     }
 
@@ -198,10 +197,12 @@ void aePolyMesh::writeSampleBody()
     {
         AbcGeom::ON3fGeomParam::Sample sp;
         sp.setVals(Abc::V3fArraySample(m_buf_normals.data(), m_buf_normals.size()));
-        if (!m_buf_normal_indices.empty())
-            sp.setIndices(Abc::UInt32ArraySample((const uint32_t*)m_buf_normal_indices.data(), m_buf_normal_indices.size()));
-        else if (m_buf_normals.size() == m_buf_points.size())
+        if (m_buf_normals.size() == m_buf_points.size())
+        {
             sp.setIndices(Abc::UInt32ArraySample((const uint32_t*)m_buf_indices.data(), m_buf_indices.size()));
+        }
+
+        sp.setScope(Alembic::AbcGeom::GeometryScope::kVertexScope);
         sample.setNormals(sp);
     }
     if (!m_buf_uv0.empty())

--- a/Source/abci/Exporter/aePolyMesh.h
+++ b/Source/abci/Exporter/aePolyMesh.h
@@ -52,7 +52,6 @@ private:
     RawVector<abcV3> m_buf_velocities;
 
     RawVector<abcV3> m_buf_normals;
-    RawVector<int>   m_buf_normal_indices;
 
     RawVector<abcV2> m_buf_uv0;
     RawVector<int>   m_buf_uv0_indices;

--- a/Source/abci/Exporter/aePolyMesh.h
+++ b/Source/abci/Exporter/aePolyMesh.h
@@ -52,15 +52,9 @@ private:
     RawVector<abcV3> m_buf_velocities;
 
     RawVector<abcV3> m_buf_normals;
-
     RawVector<abcV2> m_buf_uv0;
-    RawVector<int>   m_buf_uv0_indices;
-
     RawVector<abcV2> m_buf_uv1;
-    RawVector<int>   m_buf_uv1_indices;
-
     RawVector<abcV4> m_buf_colors;
-    RawVector<int>   m_buf_colors_indices;
 
     std::vector<SubmeshBuffer> m_buf_submeshes;
     RawVector<int> m_tmp_facecet;

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fixed a bug that caused the Alembic exporter to fail if GameObjects were being deleted during the recording session.
 - Fixed a memory leak that occurred when using varying topology meshes.
+- Fixed a bug that caused the exported mesh normals to be unreadable in DCCs.
 
 ## [2.2.0-exp.2] - 2021-01-21
 ### Added


### PR DESCRIPTION
The bug was caused by the fact that the normals did not have the correct scope. All vertex attributes suffer from this issue:
UV1, UV2, Colours, Normals.

If number of Indices is the same as the number of faces * 3 (every point is used in only 1 face ), attributes are FaceVarying, else they are Vertex scope