### PR TITLE
JIRA: ABC-201 Memory leak in the Chase Cinematic template

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a bug that caused the Alembic exporter to fail if GameObjects were being deleted during the recording session.
 - Fixed a memory leak that occurred when using varying topology meshes.
 - Fixed a bug that caused the exported mesh normals to be unreadable in DCCs.
+- Fixed a bug that caused memory leaks when the same StreamPlayer was being Enabled/Disabled/Updated on the same frame.
 
 ## [2.2.0-exp.2] - 2021-01-21
 ### Added

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -182,6 +182,11 @@ namespace UnityEngine.Formats.Alembic.Importer
         {
             if (StreamDescriptor == null)
                 return false;
+            if (abcStream != null)
+            {
+                abcStream.Dispose();
+            }
+
             abcStream = new AlembicStream(gameObject, StreamDescriptor);
             var ret = abcStream.AbcLoad(createMissingNodes, false);
             forceUpdate = true;
@@ -257,7 +262,11 @@ namespace UnityEngine.Formats.Alembic.Importer
         void OnDisable()
         {
             if (abcStream != null)
+            {
                 abcStream.Dispose();
+            }
+
+            abcStream = null;
         }
 
         void OnApplicationQuit()

--- a/com.unity.formats.alembic/Tests/Editor/Unity.Formats.Alembic.Editor.Tests.asmdef
+++ b/com.unity.formats.alembic/Tests/Editor/Unity.Formats.Alembic.Editor.Tests.asmdef
@@ -1,14 +1,25 @@
 {
     "name": "Unity.Formats.Alembic.UnitTests.Editor",
+    "rootNamespace": "",
     "references": [
-        "Unity.Formats.Alembic.Runtime"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "Unity.Formats.Alembic.Runtime",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Unity.Timeline"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
Bug was caused by having multiple timeline tracks that enable/disable/update the same AlembicStreamPlayer on the same frame. Because of that the same stream would be reopened without destroying the old stream.

@cguer My repro steps:
Play the chase demo once from the beginning to the end. 
Exit playmode
Replay the chase and notice the console errors
Please also check https://jira.unity3d.com/browse/ABC-90 : I unable to repro with my fix and cause seems to be related.