### PR TITLE
AlembicRecorder Test project fix.

### DIFF
--- a/TestProjects/AlembicRecorder/Packages/manifest.json
+++ b/TestProjects/AlembicRecorder/Packages/manifest.json
@@ -33,8 +33,5 @@
     "com.unity.modules.xr": "1.0.0"
   },
   "enableLockFile": true,
-  "resolutionStrategy": "highest",
-  "testabls": [
-    "com.unity.formats.alembic"
-  ]
+  "resolutionStrategy": "highest"
 }


### PR DESCRIPTION
Fix a typo inside the AlembicRecorder Test project that led you to believe that all alembic tests were ran.