### PR TITLE
Last minute tweaks

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0-pre.1] - 2021-04-07
+## [2.2.0-pre.2] - 2021-04-07
 ### Added
 - New option to automatically add the AlembicCurveRendering components for basic preview of the curves in the Scene.
 - New option to stream Alembic files from outside a Unity project.

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesElement.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesElement.cs
@@ -1,4 +1,3 @@
-using Scripts.Importer;
 using UnityEngine.Formats.Alembic.Sdk;
 
 namespace UnityEngine.Formats.Alembic.Importer

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesRenderer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicCurvesRenderer.cs
@@ -9,7 +9,7 @@ using UnityEngine.Formats.Alembic.Importer;
 using UnityEngine.Rendering;
 using Unity.Burst;
 
-namespace Scripts.Importer
+namespace UnityEngine.Formats.Alembic.Importer
 {
     /// <summary>
     /// The AlembicCurvesRenderer component allows you to preview the data inside an AlembicCurves component. It requires the AlembicCurves component to function correctly. When you add an AlembicCurvesRenderer component, it also automatically adds two other required components: a MeshRenderer and a MeshFilter.

--- a/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.api
+++ b/com.unity.formats.alembic/Runtime/Unity.Formats.Alembic.Runtime.api
@@ -1,14 +1,6 @@
 // This file is generated. Do not modify by hand.
 // XML documentation file not found. To check if public methods have XML comments,
 // make sure the XML doc file is present and located next to the scraped dll
-namespace Scripts.Importer
-{
-    [UnityEngine.ExecuteInEditMode] [UnityEngine.RequireComponent(typeof(UnityEngine.Formats.Alembic.Importer.AlembicCurves))] [UnityEngine.RequireComponent(typeof(UnityEngine.MeshFilter))] [UnityEngine.RequireComponent(typeof(UnityEngine.MeshRenderer))] public class AlembicCurvesRenderer : UnityEngine.MonoBehaviour
-    {
-        public AlembicCurvesRenderer() {}
-    }
-}
-
 namespace UnityEngine.Formats.Alembic.Exporter
 {
     [UnityEngine.ExecuteInEditMode] public class AlembicExporter : UnityEngine.MonoBehaviour
@@ -36,6 +28,11 @@ namespace UnityEngine.Formats.Alembic.Importer
         public float[] Widths { get; }
         public AlembicCurves() {}
         public delegate void OnUpdateDataHandler(UnityEngine.Formats.Alembic.Importer.AlembicCurves curves);
+    }
+
+    [UnityEngine.ExecuteInEditMode] [UnityEngine.RequireComponent(typeof(UnityEngine.Formats.Alembic.Importer.AlembicCurves))] [UnityEngine.RequireComponent(typeof(UnityEngine.MeshFilter))] [UnityEngine.RequireComponent(typeof(UnityEngine.MeshRenderer))] public class AlembicCurvesRenderer : UnityEngine.MonoBehaviour
+    {
+        public AlembicCurvesRenderer() {}
     }
 
     [UnityEngine.ExecuteInEditMode] public class AlembicPointsCloud : UnityEngine.MonoBehaviour

--- a/com.unity.formats.alembic/Tests/Editor/EditorTests.cs
+++ b/com.unity.formats.alembic/Tests/Editor/EditorTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Linq;
 using NUnit.Framework;
-using Scripts.Importer;
 using UnityEngine;
 using UnityEngine.Formats.Alembic.Importer;
 using UnityEngine.Formats.Alembic.Sdk;

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -15,5 +15,5 @@
   ],
   "name": "com.unity.formats.alembic",
   "unity": "2019.4",
-  "version": "2.2.0-pre.1"
+  "version": "2.2.0-pre.2"
 }


### PR DESCRIPTION
Noticed last minute that the AlembicCurvesRenderer was in the wrong namespace.

* Move AlembicCurvesRenderer to UnityEngine.Formats.Alembic.Importer
* Updated the package version to 2.2.0-pre.2