### PR TITLE
JIRA: ABC-221 Importing an ABC file creates undo events

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - Fixed a bug that was converting previous Alembic instance in prefabs into out-of-project references.
+- Fixed a bug that was polluting the Undo stack while assets were being imported.
 
 ## [2.2.0-pre.3] - 2021-04-07
 ### Added

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - Fixed a bug that was converting previous Alembic instance in prefabs into out-of-project references.
-- Fixed a bug that was polluting the Undo stack while assets were being imported.
+- Fixed a bug that was adding unnecessary Undo events during the Alembic asset import process.
 
 ## [2.2.0-pre.3] - 2021-04-07
 ### Added


### PR DESCRIPTION
While importing assets, you can notice 
"Create Alembic Object" undo events.
This PR does a scope guard that disables undos for all editor GO and Component creation code.