### PR TITLE
JIRA: ABC-222 Alembic Reimports on on every SRP project start

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - Fixed a bug that was converting previous Alembic instance in prefabs into out-of-project references.
-- Fixed a bug that was causing Alembic files to be re-imported on every SRP project start.
+- Fixed a bug that was re-importing Alembic files on every SRP project start.
 
 ## [2.2.0-pre.3] - 2021-04-07
 ### Added

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - Fixed a bug that was converting previous Alembic instance in prefabs into out-of-project references.
+- Fixed a bug that was causing Alembic files to be re-imported on every SRP project start.
 
 ## [2.2.0-pre.3] - 2021-04-07
 ### Added

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -215,22 +215,15 @@ namespace UnityEditor.Formats.Alembic.Importer
         static void InitializeEditorCallback()
         {
             EditorApplication.update += DirtyCustomDependencies; //
+            pipelineHash = ComputeHash();
         }
 
         static ulong pipelineHash;
         static readonly TimeSpan checkDependencyFrequency = TimeSpan.FromSeconds(5);
         static DateTime lastCheck;
 
-        static void DirtyCustomDependencies()
+        static ulong ComputeHash()
         {
-            var now = DateTime.Now;
-            if (Application.isPlaying || now - lastCheck < checkDependencyFrequency)
-            {
-                return;
-            }
-
-            lastCheck = now;
-
             var newPipelineHash = 0UL;
             if (GraphicsSettings.currentRenderPipeline == null)
             {
@@ -245,6 +238,21 @@ namespace UnityEditor.Formats.Alembic.Importer
                         RuntimeUtils.CombineHash((ulong)guid.GetHashCode(), (ulong)fileId);
                 }
             }
+
+            return newPipelineHash;
+        }
+
+        static void DirtyCustomDependencies()
+        {
+            var now = DateTime.Now;
+            if (Application.isPlaying || now - lastCheck < checkDependencyFrequency)
+            {
+                return;
+            }
+
+            lastCheck = now;
+
+            var newPipelineHash = ComputeHash();
             if (pipelineHash != newPipelineHash)
             {
                 pipelineHash = newPipelineHash;


### PR DESCRIPTION
The bug was caused by the fact that when the editor restarts the pipeline dependency is not consistent with the current value.