### PR TITLE
[ABC-223] Standalone Alembic Builds fail when building twice with read only assets 

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - Fixed a bug that was converting previous Alembic instance in prefabs into out-of-project references.
-- Fixed a bug that caused standalone builds to fail when the Alembic assets are read-only.
 - Fixed a bug that was re-importing Alembic files on every SRP project start.
+- Fixed a bug that caused standalone builds to fail when the Alembic assets are read-only.
 
 ## [2.2.0-pre.3] - 2021-04-07
 ### Added

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - Fixed a bug that was converting previous Alembic instance in prefabs into out-of-project references.
+- Fixed a bug that caused standalone builds to fail when the Alembic assets are read-only.
 
 ## [2.2.0-pre.3] - 2021-04-07
 ### Added

--- a/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
@@ -16,7 +16,7 @@ namespace UnityEditor.Formats.Alembic.Importer
 {
     static class AlembicBuildPostProcess
     {
-        internal static readonly List<KeyValuePair<string, string>> FilesToCopy = new List<KeyValuePair<string, string>>();
+        internal static readonly HashSet<KeyValuePair<string, string>> FilesToCopy = new HashSet<KeyValuePair<string, string>>();
         internal static bool HaveAlembicInstances = false;
         [PostProcessBuild]
         public static void OnPostProcessBuild(BuildTarget target, string pathToBuiltProject)
@@ -42,6 +42,12 @@ namespace UnityEditor.Formats.Alembic.Importer
                     Directory.CreateDirectory(dir);
                 }
 
+                if (File.Exists(files.Value))
+                {
+                    var attrs = File.GetAttributes(files.Value);
+                    attrs &= ~FileAttributes.ReadOnly;
+                    File.SetAttributes(files.Value, attrs);
+                }
                 File.Copy(files.Key, files.Value, true);
             }
             FilesToCopy.Clear();


### PR DESCRIPTION
Overwrite file.copy arg does not work on readonly files on Windows.
Also added a small optimization to not copy the same file multiple times (multiple instances of the same file.)